### PR TITLE
Update ID-1 startup to ensure repo clone

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -24,7 +24,7 @@ sudo cset shield --exec -- sh -c '
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l6 -I 500 --no-multiplex --all -x, \
     -o /local/data/results/id_1_toplev.csv -- \
-      taskset -c 6 /local/code/Laelaps_C/main \
+      taskset -c 6 /local/bci_code/id_1/main \
         >> /local/data/results/id_1_toplev.log 2>&1
 '
 
@@ -39,7 +39,7 @@ sudo cset shield --exec -- sh -c '
   MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
   # Run the same workload on core 6, log its output
-  taskset -c 6 /local/code/Laelaps_C/main \
+  taskset -c 6 /local/bci_code/id_1/main \
     >> /local/data/results/id_1_maya.log 2>&1
 
   # After workload exits, terminate Maya

--- a/scripts/startup_1.sh
+++ b/scripts/startup_1.sh
@@ -174,14 +174,39 @@ sudo /local/tools/pmu-tools/event_download.py
 
 ### Setting up ID-1 (Seizure Detection - Laelaps)
 
-# Create directories
-cd /local/; mkdir -p code; cd code
-# Download Laelaps code (OpenMP version)
-wget http://ieeg-swez.ethz.ch/DATE2019/Laelaps_OpenMP.zip
-# Unzip
-unzip Laelaps_OpenMP.zip
-# Install
-cd Laelaps_C/;
+# Clone the bci_code repository if it's not already present
+cd /local
+if [ ! -d bci_code ]; then
+    git clone https://github.com/vickariofillis/bci_code.git
+fi
+
+# Set variables for the source and destination directories
+PROJECT_DATA="/proj/nejsustain-PG0/data/bci/id-1"
+DEST_CODE="/local/bci_code/id_1"
+
+# Ensure destination directory exists and move there
+mkdir -p ${DEST_CODE}
+cd ${DEST_CODE}
+
+# Copy data.h if available in project storage; otherwise download it
+if [ -f "${PROJECT_DATA}/data.h" ]; then
+    echo "Found data.h in project storage. Copying..."
+    cp "${PROJECT_DATA}/data.h" .
+else
+    echo "data.h not found. Downloading..."
+    curl -L "https://drive.usercontent.google.com/download?id=1HFm67GHZZbtzRSB4ZXcjuUNn5Gh9uI93&confirm=xxx" -o data.h
+fi
+
+# Copy data2.h if available in project storage; otherwise download it
+if [ -f "${PROJECT_DATA}/data2.h" ]; then
+    echo "Found data2.h in project storage. Copying..."
+    cp "${PROJECT_DATA}/data2.h" .
+else
+    echo "data2.h not found. Downloading..."
+    curl -L "https://drive.usercontent.google.com/download?id=1Yi9pr8-RFxi_9xgks_7h_HWjAZ5tmTnu&confirm=xxx" -o data2.h
+fi
+
+# Compile the Laelaps program
 gcc main.c -o main
 # If we want to use OpenMP
 # gcc -fopenmp main.c -o main


### PR DESCRIPTION
## Summary
- clone `bci_code` repo in the ID‑1 setup if it is missing

## Testing
- `shellcheck scripts/startup_1.sh scripts/run_1.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847584a11cc832ca7418bed21deb68f