### PR TITLE
Fix startup 13 repo cloning

### DIFF
--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -315,8 +315,15 @@ fi
 
 ### Setting up ID-13 (Movement Intent)
 
+# Clone repo in case it was not fetched earlier
+cd /local
+if [ ! -d bci_code ]; then
+  git clone https://github.com/vickariofillis/bci_code.git
+fi
+
 # Create directories
-cd /local; mkdir -p tools; cd tools
+mkdir -p tools
+cd tools
 
 # Download Fieldtrip
 curl -L "https://drive.usercontent.google.com/download?id={1KVb_tsA1KzC7AhaZUKvR0wuR9Ob9bTJe}&confirm=xxx" -o fieldtrip-20240916.zip


### PR DESCRIPTION
## Summary
- ensure ID-13 startup script clones the repository if missing

## Testing
- `shellcheck scripts/startup_13.sh`

------
https://chatgpt.com/codex/tasks/task_e_68476227a6c4832c94b9cc12acd12a7f