### PR TITLE
Add completion indicator to run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -61,3 +61,6 @@ awk '
 ' /local/data/results/id_1_maya.txt > /local/data/results/id_1_maya.csv
 
 echo "All done. Results are in /local/data/results/"
+
+# Signal completion for tmux monitoring
+echo Done > /local/data/results/done.log

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -19,3 +19,6 @@ cd ~;
 cset shield --cpu 5,6,15,16 --kthread=on
 
 # Toplev profiling
+
+# Signal completion for script monitoring
+echo Done > /local/data/results/done.log

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -130,3 +130,6 @@ awk '
 ' /local/data/results/id_20_llm_maya.txt > /local/data/results/id_20_llm_maya.csv
 
 echo "Maya profiling complete; CSVs available in /local/data/results/"
+
+# Indicate completion for external monitoring tools
+echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -157,3 +157,6 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
   > /local/data/results/id_20_3gram_llm_maya.csv
 
 echo "Maya profiling complete; CSVs are in /local/data/results/"
+
+# Signal completion
+echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -73,3 +73,6 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
   > /local/data/results/id_20_3gram_llm_maya.csv
 
 echo "Maya profiling complete; CSVs are in /local/data/results/"
+
+# Signal completion
+echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -73,3 +73,6 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
   > /local/data/results/id_20_3gram_lm_maya.csv
 
 echo "Maya profiling complete; CSVs are in /local/data/results/"
+
+# Signal completion
+echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -75,3 +75,6 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
   > /local/data/results/id_20_3gram_rnn_maya.csv
 
 echo "Maya profiling complete; CSVs are in /local/data/results/"
+
+# Signal completion
+echo Done > /local/data/results/done.log


### PR DESCRIPTION
## Summary
- add a completion marker in all scripts/ run scripts
- revert changes to other scripts that shouldn't have the marker

## Testing
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684767de6004832cafe81cb07cdbfd52