### PR TITLE
Complete run_13 script and adjust startup

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -63,4 +63,7 @@ awk '
 echo "All done. Results are in /local/data/results/"
 
 # Signal completion for tmux monitoring
+
+################################################################################
+
 echo Done > /local/data/results/done.log

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -2,23 +2,72 @@
 set -euo pipefail
 
 ################################################################################
-
 ### Create results directory (if it doesn't exist already)
-cd /local; mkdir -p data; cd data; mkdir -p results;
+################################################################################
+cd /local; mkdir -p data/results
 # Get ownership of /local and grant read and execute permissions to everyone
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
 ################################################################################
-
 ### Run workload ID-13 (Movement Intent)
-
-cd ~;
+################################################################################
+cd ~
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 cset shield --cpu 5,6,15,16 --kthread=on
 
-# Toplev profiling
+################################################################################
+### Toplev profiling
+################################################################################
+
+sudo -E cset shield --exec -- bash -lc '
+  export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
+  export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
+  export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l6 -I 500 --no-multiplex --all -x, \
+    -o /local/data/results/id_13_toplev.csv -- \
+      taskset -c 6 /local/tools/matlab/bin/matlab \
+        -nodisplay -nosplash \
+        -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
+' &> /local/data/results/id_13_toplev.log
+
+################################################################################
+### Maya profiling
+################################################################################
+
+sudo -E cset shield --exec -- bash -lc '
+  export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
+  export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
+  export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
+
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_13_maya.txt 2>&1 &
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  taskset -c 6 /local/tools/matlab/bin/matlab \
+    -nodisplay -nosplash \
+    -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
+    >> /local/data/results/id_13_maya.log 2>&1
+
+  kill "$MAYA_PID"
+'
+
+################################################################################
+### Convert Maya raw output to CSV
+################################################################################
+
+echo "Converting id_13_maya.txt → id_13_maya.csv"
+awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?"," : "") } print "" }' \
+  /local/data/results/id_13_maya.txt > /local/data/results/id_13_maya.csv
+
+echo "All done. Results are in /local/data/results/"
 
 # Signal completion for script monitoring
+
+################################################################################
+
 echo Done > /local/data/results/done.log

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -132,4 +132,7 @@ awk '
 echo "Maya profiling complete; CSVs available in /local/data/results/"
 
 # Indicate completion for external monitoring tools
+
+################################################################################
+
 echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -159,4 +159,7 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
 echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 # Signal completion
+
+################################################################################
+
 echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -75,4 +75,7 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
 echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 # Signal completion
+
+################################################################################
+
 echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -75,4 +75,7 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
 echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 # Signal completion
+
+################################################################################
+
 echo Done > /local/data/results/done.log

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -77,4 +77,7 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
 echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 # Signal completion
+
+################################################################################
+
 echo Done > /local/data/results/done.log


### PR DESCRIPTION
## Summary
- implement full workflow for ID-13 including toplev and Maya runs
- ensure MATLAB preference directory ownership in startup
- add visual delimiter before done log creation in all run scripts
- fix spacing around delimiter comment lines

## Testing
- `shellcheck scripts/run_13.sh`
- `for f in scripts/run_*.sh; do shellcheck "$f"; done`
- `shellcheck scripts/startup_13.sh`
- `sudo apt-get update`
- `sudo apt-get install -y shellcheck`


------
https://chatgpt.com/codex/tasks/task_e_6848c3d0f9a8832cb743d57f783edbe6