### PR TITLE
Add runtime reporting to run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Format seconds as "Xd Yh Zm"
+secs_to_dhm() {
+  local total=$1
+  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+}
+
 ################################################################################
 
 # Create results directory (if it doesn't exist already)
@@ -18,6 +24,7 @@ cd ~
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 sudo cset shield --cpu 5,6,15,16 --kthread=on
+toplev_start=$(date +%s)
 
 # Toplev profiling
 sudo cset shield --exec -- sh -c '
@@ -28,7 +35,9 @@ sudo cset shield --exec -- sh -c '
         >> /local/data/results/id_1_toplev.log 2>&1
 '
 
+toplev_end=$(date +%s)
 # Maya profiling
+maya_start=$(date +%s)
 sudo cset shield --exec -- sh -c '
   # Start Maya on core 5 in background, log raw output
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
@@ -45,6 +54,7 @@ sudo cset shield --exec -- sh -c '
   # After workload exits, terminate Maya
   kill "$MAYA_PID"
 '
+maya_end=$(date +%s)
 
 ################################################################################
 
@@ -66,4 +76,14 @@ echo "All done. Results are in /local/data/results/"
 
 ################################################################################
 
-echo Done > /local/data/results/done.log
+
+# Write completion file with runtimes
+toplev_runtime=$((toplev_end - toplev_start))
+maya_runtime=$((maya_end - maya_start))
+cat <<EOF > /local/data/results/done.log
+Done
+
+Toplev runtime: $(secs_to_dhm "$toplev_runtime")
+
+Maya runtime:   $(secs_to_dhm "$maya_runtime")
+EOF

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# Format seconds as "Xd Yh Zm"
+secs_to_dhm() {
+  local total=$1
+  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+}
+
 ################################################################################
 ### Create results directory (if it doesn't exist already)
 ################################################################################
@@ -16,6 +22,7 @@ cd ~
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 cset shield --cpu 5,6,15,16 --kthread=on
+toplev_start=$(date +%s)
 
 ################################################################################
 ### Toplev profiling
@@ -33,10 +40,12 @@ sudo -E cset shield --exec -- bash -lc '
         -nodisplay -nosplash \
         -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
 ' &> /local/data/results/id_13_toplev.log
+toplev_end=$(date +%s)
 
 ################################################################################
 ### Maya profiling
 ################################################################################
+maya_start=$(date +%s)
 
 sudo -E cset shield --exec -- bash -lc '
   export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -55,6 +64,7 @@ sudo -E cset shield --exec -- bash -lc '
 
   kill "$MAYA_PID"
 '
+maya_end=$(date +%s)
 
 ################################################################################
 ### Convert Maya raw output to CSV
@@ -70,4 +80,14 @@ echo "All done. Results are in /local/data/results/"
 
 ################################################################################
 
-echo Done > /local/data/results/done.log
+
+# Write completion file with runtimes
+toplev_runtime=$((toplev_end - toplev_start))
+maya_runtime=$((maya_end - maya_start))
+cat <<EOF > /local/data/results/done.log
+Done
+
+Toplev runtime: $(secs_to_dhm "$toplev_runtime")
+
+Maya runtime:   $(secs_to_dhm "$maya_runtime")
+EOF

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# Format seconds as "Xd Yh Zm"
+secs_to_dhm() {
+  local total=$1
+  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -13,6 +19,7 @@ chmod -R a+rx /local
 ### 2. Shield CPUs 5, 6, 15, and 16 (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6,15,16 --kthread=on
+toplev_start=$(date +%s)
 
 ################################################################################
 ### 3. Change into the BCI project directory
@@ -67,9 +74,11 @@ sudo -E cset shield --exec -- bash -lc '
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
 ' &> /local/data/results/id_20_3gram_llm_toplev.log
+toplev_end=$(date +%s)
 
 ################################################################################
 ### 5. Maya profiling
+maya_start=$(date +%s)
 ################################################################################
 
 # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -136,6 +145,7 @@ sudo -E cset shield --exec -- bash -lc '
 
   kill "$MAYA_PID"
 '
+maya_end=$(date +%s)
 
 ################################################################################
 ### 6. Convert Maya raw output files into CSV
@@ -162,4 +172,14 @@ echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 ################################################################################
 
-echo Done > /local/data/results/done.log
+
+# Write completion file with runtimes
+toplev_runtime=$((toplev_end - toplev_start))
+maya_runtime=$((maya_end - maya_start))
+cat <<EOF > /local/data/results/done.log
+Done
+
+Toplev runtime: $(secs_to_dhm "$toplev_runtime")
+
+Maya runtime:   $(secs_to_dhm "$maya_runtime")
+EOF

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+# Format seconds as "Xd Yh Zm"
+secs_to_dhm() {
+  local total=$1
+  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
 # Get ownership of /local and grant read and execute permissions to everyone
 chown -R "$USER":"$(id -gn)" /local
+toplev_start=$(date +%s)
 chmod -R a+rx /local
 
 ################################################################################
@@ -37,9 +44,11 @@ sudo -E cset shield --exec -- bash -lc '
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
 ' &> /local/data/results/id_20_3gram_llm_toplev.log
+toplev_end=$(date +%s)
 
 ################################################################################
 ### 5. Maya profiling
+maya_start=$(date +%s)
 ################################################################################
 
 # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -62,6 +71,7 @@ sudo -E cset shield --exec -- bash -lc '
 
   kill "$MAYA_PID"
 '
+maya_end=$(date +%s)
 
 ################################################################################
 ### 6. Convert Maya raw output files into CSV
@@ -78,4 +88,14 @@ echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 ################################################################################
 
-echo Done > /local/data/results/done.log
+
+# Write completion file with runtimes
+toplev_runtime=$((toplev_end - toplev_start))
+maya_runtime=$((maya_end - maya_start))
+cat <<EOF > /local/data/results/done.log
+Done
+
+Toplev runtime: $(secs_to_dhm "$toplev_runtime")
+
+Maya runtime:   $(secs_to_dhm "$maya_runtime")
+EOF

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+# Format seconds as "Xd Yh Zm"
+secs_to_dhm() {
+  local total=$1
+  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
 # Get ownership of /local and grant read and execute permissions to everyone
 chown -R "$USER":"$(id -gn)" /local
+toplev_start=$(date +%s)
 chmod -R a+rx /local
 
 ################################################################################
@@ -30,6 +37,7 @@ sudo -E cset shield --exec -- bash -lc '
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
+toplev_end=$(date +%s)
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l6 -I 500 --no-multiplex --all -x, \
     -o /local/data/results/id_20_3gram_rnn_toplev.csv -- \
@@ -40,6 +48,7 @@ sudo -E cset shield --exec -- bash -lc '
 
 ################################################################################
 ### 5. Maya profiling
+maya_start=$(date +%s)
 ################################################################################
 
 # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -64,6 +73,7 @@ sudo -E cset shield --exec -- bash -lc '
 
   kill "$MAYA_PID"
 '
+maya_end=$(date +%s)
 
 ################################################################################
 ### 6. Convert Maya raw output files into CSV
@@ -80,4 +90,14 @@ echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 ################################################################################
 
-echo Done > /local/data/results/done.log
+
+# Write completion file with runtimes
+toplev_runtime=$((toplev_end - toplev_start))
+maya_runtime=$((maya_end - maya_start))
+cat <<EOF > /local/data/results/done.log
+Done
+
+Toplev runtime: $(secs_to_dhm "$toplev_runtime")
+
+Maya runtime:   $(secs_to_dhm "$maya_runtime")
+EOF


### PR DESCRIPTION
## Summary
- log start/end times for toplev and Maya blocks in all run scripts
- compute elapsed time and write it to `/local/data/results/done.log`

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_3.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851ef7ab89c832c8666bbdc725f047f