### PR TITLE
Add tool selection to run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -9,6 +9,42 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Parse tool selection arguments inside tmux
+run_toplev=false
+run_maya=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toplev) run_toplev=true ;;
+    --maya)   run_maya=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+  esac
+  shift
+done
+if ! $run_toplev && ! $run_maya; then
+  run_toplev=true
+  run_maya=true
+fi
+
+# Describe this workload
+workload_desc="ID-1 (Seizure Detection – Laelaps)"
+
+# Announce planned run and provide 10s window to cancel
+tools_list=()
+$run_toplev && tools_list+=("toplev")
+$run_maya && tools_list+=("maya")
+tool_msg=$(IFS=, ; echo "${tools_list[*]}")
+echo "Testing $workload_desc with tools: $tool_msg"
+for i in {10..1}; do
+  echo "$i"
+  sleep 1
+done
+
+# Initialize timing variables
+toplev_start=0
+toplev_end=0
+maya_start=0
+maya_end=0
+
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
   local total=$1
@@ -32,51 +68,54 @@ cd ~
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 sudo cset shield --cpu 5,6,15,16 --kthread=on
-toplev_start=$(date +%s)
 
-# Toplev profiling
-sudo cset shield --exec -- sh -c '
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 --no-multiplex --all -x, \
-    -o /local/data/results/id_1_toplev.csv -- \
-      taskset -c 6 /local/bci_code/id_1/main \
-        >> /local/data/results/id_1_toplev.log 2>&1
-'
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  sudo cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_1_toplev.csv -- \
+        taskset -c 6 /local/bci_code/id_1/main \
+          >> /local/data/results/id_1_toplev.log 2>&1
+  '
+  toplev_end=$(date +%s)
+fi
 
-toplev_end=$(date +%s)
-# Maya profiling
-maya_start=$(date +%s)
-sudo cset shield --exec -- sh -c '
-  # Start Maya on core 5 in background, log raw output
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_1_maya.txt 2>&1 &
+if $run_maya; then
+  maya_start=$(date +%s)
+  sudo cset shield --exec -- sh -c '
+    # Start Maya on core 5 in background, log raw output
+    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+      > /local/data/results/id_1_maya.txt 2>&1 &
 
-  # Give Maya a moment to start and then grab its PID
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+    # Give Maya a moment to start and then grab its PID
+    sleep 1
+    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-  # Run the same workload on core 6, log its output
-  taskset -c 6 /local/bci_code/id_1/main \
-    >> /local/data/results/id_1_maya.log 2>&1
+    # Run the same workload on core 6, log its output
+    taskset -c 6 /local/bci_code/id_1/main \
+      >> /local/data/results/id_1_maya.log 2>&1
 
-  # After workload exits, terminate Maya
-  kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
+    # After workload exits, terminate Maya
+    kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+fi
 
 ################################################################################
 
-### Convert Maya raw output to CSV
-
-echo "Converting Maya output to CSV → /local/data/results/id_1_maya.csv"
-awk '
-{
-  for (i = 1; i <= NF; i++) {
-    printf "%s%s", $i, (i < NF ? "," : "")
+if $run_maya; then
+  ### Convert Maya raw output to CSV
+  echo "Converting Maya output to CSV → /local/data/results/id_1_maya.csv"
+  awk '
+  {
+    for (i = 1; i <= NF; i++) {
+      printf "%s%s", $i, (i < NF ? "," : "")
+    }
+    print ""
   }
-  print ""
-}
-' /local/data/results/id_1_maya.txt > /local/data/results/id_1_maya.csv
+  ' /local/data/results/id_1_maya.txt > /local/data/results/id_1_maya.csv
+fi
 
 echo "All done. Results are in /local/data/results/"
 
@@ -86,12 +125,18 @@ echo "All done. Results are in /local/data/results/"
 
 
 # Write completion file with runtimes
-toplev_runtime=$((toplev_end - toplev_start))
-maya_runtime=$((maya_end - maya_start))
-cat <<EOF > /local/data/results/done.log
-Done
-
-Toplev runtime: $(secs_to_dhm "$toplev_runtime")
-
-Maya runtime:   $(secs_to_dhm "$maya_runtime")
-EOF
+toplev_runtime=0
+maya_runtime=0
+{
+  echo "Done"
+  if $run_toplev; then
+    toplev_runtime=$((toplev_end - toplev_start))
+    echo
+    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
+  fi
+  if $run_maya; then
+    maya_runtime=$((maya_end - maya_start))
+    echo
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+} > /local/data/results/done.log

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -9,6 +9,42 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Parse tool selection arguments inside tmux
+run_toplev=false
+run_maya=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toplev) run_toplev=true ;;
+    --maya)   run_maya=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+  esac
+  shift
+done
+if ! $run_toplev && ! $run_maya; then
+  run_toplev=true
+  run_maya=true
+fi
+
+# Describe this workload
+workload_desc="ID-13 (Movement Intent)"
+
+# Announce planned run and provide 10s window to cancel
+tools_list=()
+$run_toplev && tools_list+=("toplev")
+$run_maya && tools_list+=("maya")
+tool_msg=$(IFS=, ; echo "${tools_list[*]}")
+echo "Testing $workload_desc with tools: $tool_msg"
+for i in {10..1}; do
+  echo "$i"
+  sleep 1
+done
+
+# Initialize timing variables
+toplev_start=0
+toplev_end=0
+maya_start=0
+maya_end=0
+
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
   local total=$1
@@ -30,57 +66,53 @@ cd ~
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 cset shield --cpu 5,6,15,16 --kthread=on
-toplev_start=$(date +%s)
+
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
+    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
+    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_13_toplev.csv -- \
+        taskset -c 6 /local/tools/matlab/bin/matlab \
+          -nodisplay -nosplash \
+          -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
+  ' &> /local/data/results/id_13_toplev.log
+  toplev_end=$(date +%s)
+fi
+
+if $run_maya; then
+  maya_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
+    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
+    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
+
+    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+      > /local/data/results/id_13_maya.txt 2>&1 &
+    sleep 1
+    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+    taskset -c 6 /local/tools/matlab/bin/matlab \
+      -nodisplay -nosplash \
+      -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
+      >> /local/data/results/id_13_maya.log 2>&1
+
+    kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+fi
 
 ################################################################################
-### Toplev profiling
-################################################################################
-
-sudo -E cset shield --exec -- bash -lc '
-  export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
-  export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
-  export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 --no-multiplex --all -x, \
-    -o /local/data/results/id_13_toplev.csv -- \
-      taskset -c 6 /local/tools/matlab/bin/matlab \
-        -nodisplay -nosplash \
-        -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
-' &> /local/data/results/id_13_toplev.log
-toplev_end=$(date +%s)
-
-################################################################################
-### Maya profiling
-################################################################################
-maya_start=$(date +%s)
-
-sudo -E cset shield --exec -- bash -lc '
-  export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
-  export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
-  export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
-
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_13_maya.txt 2>&1 &
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  taskset -c 6 /local/tools/matlab/bin/matlab \
-    -nodisplay -nosplash \
-    -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
-    >> /local/data/results/id_13_maya.log 2>&1
-
-  kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
-
-################################################################################
+if $run_maya; then
 ### Convert Maya raw output to CSV
-################################################################################
-
 echo "Converting id_13_maya.txt → id_13_maya.csv"
 awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?"," : "") } print "" }' \
   /local/data/results/id_13_maya.txt > /local/data/results/id_13_maya.csv
+fi
 
 echo "All done. Results are in /local/data/results/"
 
@@ -90,12 +122,18 @@ echo "All done. Results are in /local/data/results/"
 
 
 # Write completion file with runtimes
-toplev_runtime=$((toplev_end - toplev_start))
-maya_runtime=$((maya_end - maya_start))
-cat <<EOF > /local/data/results/done.log
-Done
-
-Toplev runtime: $(secs_to_dhm "$toplev_runtime")
-
-Maya runtime:   $(secs_to_dhm "$maya_runtime")
-EOF
+toplev_runtime=0
+maya_runtime=0
+{
+  echo "Done"
+  if $run_toplev; then
+    toplev_runtime=$((toplev_end - toplev_start))
+    echo
+    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
+  fi
+  if $run_maya; then
+    maya_runtime=$((maya_end - maya_start))
+    echo
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+} > /local/data/results/done.log

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -9,6 +9,42 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Parse tool selection arguments inside tmux
+run_toplev=false
+run_maya=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toplev) run_toplev=true ;;
+    --maya)   run_maya=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+  esac
+  shift
+done
+if ! $run_toplev && ! $run_maya; then
+  run_toplev=true
+  run_maya=true
+fi
+
+# Describe this workload
+workload_desc="ID-20 (Speech Decoding)"
+
+# Announce planned run and provide 10s window to cancel
+tools_list=()
+$run_toplev && tools_list+=("toplev")
+$run_maya && tools_list+=("maya")
+tool_msg=$(IFS=, ; echo "${tools_list[*]}")
+echo "Testing $workload_desc with tools: $tool_msg"
+for i in {10..1}; do
+  echo "$i"
+  sleep 1
+done
+
+# Initialize timing variables
+toplev_start=0
+toplev_end=0
+maya_start=0
+maya_end=0
+
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
   local total=$1
@@ -31,7 +67,6 @@ cd ~;
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 cset shield --cpu 5,6,15,16 --kthread=on
-toplev_start=$(date +%s)
 
 # Move to proper directory
 cd /local/tools/bci_project/
@@ -42,94 +77,100 @@ source /local/tools/bci_env/bin/activate
 # Export PYTHONPATH
 export PYTHONPATH=$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:$PYTHONPATH
 
-### Toplev profiling
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  ### Toplev profiling
 
-# Run the RNN script
-sudo -E cset shield --exec -- sh -c '
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 --no-multiplex --all -x, \
-    -o /local/data/results/id_20_rnn_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/ \
-        >> /local/data/results/id_20_rnn_toplev.log 2>&1
-'
+  # Run the RNN script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_20_rnn_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/ \
+          >> /local/data/results/id_20_rnn_toplev.log 2>&1
+  '
 
-# Run the LM script
-sudo -E cset shield --exec -- sh -c '
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 --no-multiplex --all -x, \
-    -o /local/data/results/id_20_lm_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-        --lmDir=/local/data/languageModel/ \
-        >> /local/data/results/id_20_lm_toplev.log 2>&1
-'
+  # Run the LM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_20_lm_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          >> /local/data/results/id_20_lm_toplev.log 2>&1
+  '
 
-# Run the LLM script
-sudo -E cset shield --exec -- sh -c '
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 --no-multiplex --all -x, \
-    -o /local/data/results/id_20_llm_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        >> /local/data/results/id_20_llm_toplev.log 2>&1
-'
-toplev_end=$(date +%s)
+  # Run the LLM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_20_llm_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          >> /local/data/results/id_20_llm_toplev.log 2>&1
+  '
+  toplev_end=$(date +%s)
+fi
 
-### Maya profiling
-maya_start=$(date +%s)
+if $run_maya; then
+  ### Maya profiling
+  maya_start=$(date +%s)
 
-# Run the RNN script
-sudo -E cset shield --exec -- sh -c '
-  # Start Maya on core 5 in background, log raw output
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_rnn_maya.txt 2>&1 &
+  # Run the RNN script
+  sudo -E cset shield --exec -- sh -c '
+    # Start Maya on core 5 in background, log raw output
+    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+      > /local/data/results/id_20_rnn_maya.txt 2>&1 &
 
-  # Give Maya a moment to start and then grab its PID
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+    # Give Maya a moment to start and then grab its PID
+    sleep 1
+    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-  # Run the RNN workload on core 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-    --datasetPath=/local/data/ptDecoder_ctc \
-    --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_rnn_maya.log 2>&1
+    # Run the RNN workload on core 6
+    taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+      --datasetPath=/local/data/ptDecoder_ctc \
+      --modelPath=/local/data/speechBaseline4/ \
+      >> /local/data/results/id_20_rnn_maya.log 2>&1
 
-  # After workload exits, terminate Maya
-  kill "$MAYA_PID"
-'
+    # After workload exits, terminate Maya
+    kill "$MAYA_PID"
+  '
 
-# Run the LM script
-sudo -E cset shield --exec -- sh -c '
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_lm_maya.txt 2>&1 &
+  # Run the LM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+      > /local/data/results/id_20_lm_maya.txt 2>&1 &
 
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+    sleep 1
+    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-    --lmDir=/local/data/languageModel/ \
-    >> /local/data/results/id_20_lm_maya.log 2>&1
+    taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+      --lmDir=/local/data/languageModel/ \
+      >> /local/data/results/id_20_lm_maya.log 2>&1
 
-  kill "$MAYA_PID"
-'
+    kill "$MAYA_PID"
+  '
 
-# Run the LLM script
-sudo -E cset shield --exec -- sh -c '
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_llm_maya.txt 2>&1 &
+  # Run the LLM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+      > /local/data/results/id_20_llm_maya.txt 2>&1 &
 
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+    sleep 1
+    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-    >> /local/data/results/id_20_llm_maya.log 2>&1
+    taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+      >> /local/data/results/id_20_llm_maya.log 2>&1
 
-  kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
+    kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+fi
 
 ################################################################################
 
+if $run_maya; then
 ### Convert Maya raw output to CSV
 
 echo "Converting id_20_rnn_maya.txt → id_20_rnn_maya.csv"
@@ -148,6 +189,7 @@ awk '
 ' /local/data/results/id_20_llm_maya.txt > /local/data/results/id_20_llm_maya.csv
 
 echo "Maya profiling complete; CSVs available in /local/data/results/"
+fi
 
 # Indicate completion for external monitoring tools
 
@@ -155,12 +197,18 @@ echo "Maya profiling complete; CSVs available in /local/data/results/"
 
 
 # Write completion file with runtimes
-toplev_runtime=$((toplev_end - toplev_start))
-maya_runtime=$((maya_end - maya_start))
-cat <<EOF > /local/data/results/done.log
-Done
-
-Toplev runtime: $(secs_to_dhm "$toplev_runtime")
-
-Maya runtime:   $(secs_to_dhm "$maya_runtime")
-EOF
+toplev_runtime=0
+maya_runtime=0
+{
+  echo "Done"
+  if $run_toplev; then
+    toplev_runtime=$((toplev_end - toplev_start))
+    echo
+    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
+  fi
+  if $run_maya; then
+    maya_runtime=$((maya_end - maya_start))
+    echo
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+} > /local/data/results/done.log

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -9,6 +9,42 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Parse tool selection arguments inside tmux
+run_toplev=false
+run_maya=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toplev) run_toplev=true ;;
+    --maya)   run_maya=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+  esac
+  shift
+done
+if ! $run_toplev && ! $run_maya; then
+  run_toplev=true
+  run_maya=true
+fi
+
+# Describe this workload
+workload_desc="ID-20 3gram LLM"
+
+# Announce planned run and provide 10s window to cancel
+tools_list=()
+$run_toplev && tools_list+=("toplev")
+$run_maya && tools_list+=("maya")
+tool_msg=$(IFS=, ; echo "${tools_list[*]}")
+echo "Testing $workload_desc with tools: $tool_msg"
+for i in {10..1}; do
+  echo "$i"
+  sleep 1
+done
+
+# Initialize timing variables
+toplev_start=0
+toplev_end=0
+maya_start=0
+maya_end=0
+
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
   local total=$1
@@ -38,8 +74,11 @@ cd /local/tools/bci_project
 ### 4. Toplev profiling
 ################################################################################
 
-# Run the LLM script under toplev (toplev on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
+if $run_toplev; then
+  toplev_start=$(date +%s)
+
+  # Run the LLM script under toplev (toplev on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
@@ -51,16 +90,18 @@ sudo -E cset shield --exec -- bash -lc '
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-' &> /local/data/results/id_20_3gram_llm_toplev.log
-toplev_end=$(date +%s)
+  ' &> /local/data/results/id_20_3gram_llm_toplev.log
+  toplev_end=$(date +%s)
+fi
 
 ################################################################################
 ### 5. Maya profiling
-maya_start=$(date +%s)
+if $run_maya; then
+  maya_start=$(date +%s)
 ################################################################################
 
-# Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
+  # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
@@ -78,10 +119,12 @@ sudo -E cset shield --exec -- bash -lc '
     >> /local/data/results/id_20_3gram_llm_maya.log 2>&1
 
   kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
+  '
+  maya_end=$(date +%s)
+fi
 
 ################################################################################
+if $run_maya; then
 ### 6. Convert Maya raw output files into CSV
 ################################################################################
 
@@ -91,6 +134,7 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
   > /local/data/results/id_20_3gram_llm_maya.csv
 
 echo "Maya profiling complete; CSVs are in /local/data/results/"
+fi
 
 # Signal completion
 
@@ -98,12 +142,18 @@ echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 
 # Write completion file with runtimes
-toplev_runtime=$((toplev_end - toplev_start))
-maya_runtime=$((maya_end - maya_start))
-cat <<EOF > /local/data/results/done.log
-Done
-
-Toplev runtime: $(secs_to_dhm "$toplev_runtime")
-
-Maya runtime:   $(secs_to_dhm "$maya_runtime")
-EOF
+toplev_runtime=0
+maya_runtime=0
+{
+  echo "Done"
+  if $run_toplev; then
+    toplev_runtime=$((toplev_end - toplev_start))
+    echo
+    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
+  fi
+  if $run_maya; then
+    maya_runtime=$((maya_end - maya_start))
+    echo
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+} > /local/data/results/done.log

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -9,6 +9,42 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Parse tool selection arguments inside tmux
+run_toplev=false
+run_maya=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toplev) run_toplev=true ;;
+    --maya)   run_maya=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+  esac
+  shift
+done
+if ! $run_toplev && ! $run_maya; then
+  run_toplev=true
+  run_maya=true
+fi
+
+# Describe this workload
+workload_desc="ID-20 3gram LM"
+
+# Announce planned run and provide 10s window to cancel
+tools_list=()
+$run_toplev && tools_list+=("toplev")
+$run_maya && tools_list+=("maya")
+tool_msg=$(IFS=, ; echo "${tools_list[*]}")
+echo "Testing $workload_desc with tools: $tool_msg"
+for i in {10..1}; do
+  echo "$i"
+  sleep 1
+done
+
+# Initialize timing variables
+toplev_start=0
+toplev_end=0
+maya_start=0
+maya_end=0
+
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
   local total=$1
@@ -38,8 +74,11 @@ cd /local/tools/bci_project
 ### 4. Toplev profiling
 ################################################################################
 
-# Run the LM script under toplev (toplev on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
+if $run_toplev; then
+  toplev_start=$(date +%s)
+
+  # Run the LM script under toplev (toplev on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
@@ -51,16 +90,18 @@ sudo -E cset shield --exec -- bash -lc '
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
         --lmDir=/local/data/languageModel/ \
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-' &> /local/data/results/id_20_3gram_lm_toplev.log
-toplev_end=$(date +%s)
+  ' &> /local/data/results/id_20_3gram_lm_toplev.log
+  toplev_end=$(date +%s)
+fi
 
 ################################################################################
 ### 5. Maya profiling
-maya_start=$(date +%s)
+if $run_maya; then
+  maya_start=$(date +%s)
 ################################################################################
 
-# Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
+  # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
@@ -78,10 +119,12 @@ sudo -E cset shield --exec -- bash -lc '
     >> /local/data/results/id_20_3gram_lm_maya.log 2>&1
 
   kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
+  '
+  maya_end=$(date +%s)
+fi
 
 ################################################################################
+if $run_maya; then
 ### 6. Convert Maya raw output files into CSV
 ################################################################################
 
@@ -91,6 +134,7 @@ awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
   > /local/data/results/id_20_3gram_lm_maya.csv
 
 echo "Maya profiling complete; CSVs are in /local/data/results/"
+fi
 
 # Signal completion
 
@@ -98,12 +142,18 @@ echo "Maya profiling complete; CSVs are in /local/data/results/"
 
 
 # Write completion file with runtimes
-toplev_runtime=$((toplev_end - toplev_start))
-maya_runtime=$((maya_end - maya_start))
-cat <<EOF > /local/data/results/done.log
-Done
-
-Toplev runtime: $(secs_to_dhm "$toplev_runtime")
-
-Maya runtime:   $(secs_to_dhm "$maya_runtime")
-EOF
+toplev_runtime=0
+maya_runtime=0
+{
+  echo "Done"
+  if $run_toplev; then
+    toplev_runtime=$((toplev_end - toplev_start))
+    echo
+    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
+  fi
+  if $run_maya; then
+    maya_runtime=$((maya_end - maya_start))
+    echo
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+} > /local/data/results/done.log

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -8,6 +8,42 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Parse tool selection arguments inside tmux
+run_toplev=false
+run_maya=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toplev) run_toplev=true ;;
+    --maya)   run_maya=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+  esac
+  shift
+done
+if ! $run_toplev && ! $run_maya; then
+  run_toplev=true
+  run_maya=true
+fi
+
+# Describe this workload
+workload_desc="ID-3 (Compression)"
+
+# Announce planned run and provide 10s window to cancel
+tools_list=()
+$run_toplev && tools_list+=("toplev")
+$run_maya && tools_list+=("maya")
+tool_msg=$(IFS=, ; echo "${tools_list[*]}")
+echo "Testing $workload_desc with tools: $tool_msg"
+for i in {10..1}; do
+  echo "$i"
+  sleep 1
+done
+
+# Initialize timing variables
+toplev_start=0
+toplev_end=0
+maya_start=0
+maya_end=0
+
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
   local total=$1
@@ -29,57 +65,68 @@ source /local/tools/compression_env/bin/activate
 
 # Remove processes from Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 sudo cset shield --cpu 5,6,15,16 --kthread=on
-toplev_start=$(date +%s)
 
+if $run_toplev; then
+  toplev_start=$(date +%s)
 
-### Toplev profiling
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/compression_env/bin/activate
+  ### Toplev profiling
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/compression_env/bin/activate
 
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 --no-multiplex --all -x, \
-    -o /local/data/results/id_3_aind_np1_flac_toplev.csv -- \
-      taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac
-' &>  /local/data/results/id_3_aind_np1_flac_toplev.log
-toplev_end=$(date +%s)
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_3_aind_np1_flac_toplev.csv -- \
+        taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac
+  ' &>  /local/data/results/id_3_aind_np1_flac_toplev.log
+  toplev_end=$(date +%s)
+fi
 
-### Maya profiling
-maya_start=$(date +%s)
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/compression_env/bin/activate
+if $run_maya; then
+  maya_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/compression_env/bin/activate
 
-  # Start Maya in the background, pinned to CPU 5
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_3_aind_np1_flac_maya.txt 2>&1 &
+    # Start Maya in the background, pinned to CPU 5
+    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+      > /local/data/results/id_3_aind_np1_flac_maya.txt 2>&1 &
 
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+    sleep 1
+    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-  # Run the workload pinned to CPU 6
-  taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac \
-    >> /local/data/results/id_3_aind_np1_flac_maya.log 2>&1
+    # Run the workload pinned to CPU 6
+    taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac \
+      >> /local/data/results/id_3_aind_np1_flac_maya.log 2>&1
 
-  kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
+    kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+fi
 
+if $run_maya; then
 ### Convert Maya output to CSV
 echo "Converting id_3_aind_np1_flac_maya.txt → id_3_aind_np1_flac_maya.csv"
 awk '{ for(i=1;i<=NF;i++){ printf "%s%s",$i,(i<NF?",":"") } print "" }' \
   /local/data/results/id_3_aind_np1_flac_maya.txt \
   > /local/data/results/id_3_aind_np1_flac_maya.csv
+fi
 
 echo "aind-np1-flac profiling complete; results in /local/data/results/"
 
 # Signal completion for script monitoring
 
 # Write completion file with runtimes
-toplev_runtime=$((toplev_end - toplev_start))
-maya_runtime=$((maya_end - maya_start))
-cat <<EOF > /local/data/results/done.log
-Done
-
-Toplev runtime: $(secs_to_dhm "$toplev_runtime")
-
-Maya runtime:   $(secs_to_dhm "$maya_runtime")
-EOF
+toplev_runtime=0
+maya_runtime=0
+{
+  echo "Done"
+  if $run_toplev; then
+    toplev_runtime=$((toplev_end - toplev_start))
+    echo
+    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
+  fi
+  if $run_maya; then
+    maya_runtime=$((maya_end - maya_start))
+    echo
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+} > /local/data/results/done.log


### PR DESCRIPTION
## Summary
- add optional `--toplev` and `--maya` flags to run scripts
- show planned workload/tools and wait 10s before running
- allow skipping tool stages and report runtimes conditionally

## Testing
- `bash -n scripts/run_*.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851f829b7f8832cb1697f352cd96550