### PR TITLE
Add credential check to startup_13.sh

### DIFF
--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure sensitive information is provided before continuing
+required_vars=(USERNAME PASSWORD VPN_SERVER LICENSE_SERVER MLM_PORT)
+missing=()
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if (( ${#missing[@]} )); then
+  echo "Missing required variables: ${missing[*]}" >&2
+  echo "Please populate them in $(basename "$0") before running." >&2
+  exit 1
+fi
+
 ################################################################################
 
 ### Log keeping


### PR DESCRIPTION
## Summary
- ensure startup_13.sh validates presence of USERNAME, PASSWORD, VPN_SERVER, LICENSE_SERVER and MLM_PORT

## Testing
- `shellcheck scripts/startup_13.sh`
- `apt-get update` *(runs successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68548df51f60832cbc3285b1c6e7b6dd