### PR TITLE
Add intel-pcm instrumentation

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -12,17 +12,20 @@ fi
 # Parse tool selection arguments inside tmux
 run_toplev=false
 run_maya=false
+run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev) run_toplev=true ;;
     --maya)   run_maya=true ;;
-    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+    --pcm)    run_pcm=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya] [--pcm]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev && ! $run_maya; then
+if ! $run_toplev && ! $run_maya && ! $run_pcm; then
   run_toplev=true
   run_maya=true
+  run_pcm=true
 fi
 
 # Describe this workload
@@ -32,6 +35,7 @@ workload_desc="ID-1 (Seizure Detection – Laelaps)"
 tools_list=()
 $run_toplev && tools_list+=("toplev")
 $run_maya && tools_list+=("maya")
+$run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
 echo "Testing $workload_desc with tools: $tool_msg"
 for i in {10..1}; do
@@ -44,6 +48,8 @@ toplev_start=0
 toplev_end=0
 maya_start=0
 maya_end=0
+pcm_start=0
+pcm_end=0
 
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
@@ -102,6 +108,41 @@ if $run_maya; then
   maya_end=$(date +%s)
 fi
 
+if $run_pcm; then
+  pcm_start=$(date +%s)
+  sudo cset shield --reset
+  sudo modprobe msr
+  sudo sh -c '
+    taskset -c 5 /local/tools/pcm/build/bin/pcm \
+      -csv=/local/data/results/id_1_pcm.csv \
+      0.5 -- \
+      taskset -c 6 /local/bci_code/id_1/main \
+    >>/local/data/results/id_1_pcm.log 2>&1
+  '
+  sudo sh -c '
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
+      -csv=/local/data/results/id_1_pcm_memory.csv \
+      0.5 -- \
+      taskset -c 6 /local/bci_code/id_1/main \
+    >>/local/data/results/id_1_pcm_memory.log 2>&1
+  '
+  sudo sh -c '
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
+      -p 0 -a 10 -b 20 -c 30 \
+      -csv=/local/data/results/id_1_pcm_power.csv -- \
+      taskset -c 6 /local/bci_code/id_1/main \
+    >>/local/data/results/id_1_pcm_power.log 2>&1
+  '
+  sudo sh -c '
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_1_pcm_pcie.csv \
+      0.5 -- \
+      taskset -c 6 /local/bci_code/id_1/main \
+    >>/local/data/results/id_1_pcm_pcie.log 2>&1
+  '
+  pcm_end=$(date +%s)
+fi
+
 ################################################################################
 
 if $run_maya; then
@@ -127,6 +168,7 @@ echo "All done. Results are in /local/data/results/"
 # Write completion file with runtimes
 toplev_runtime=0
 maya_runtime=0
+pcm_runtime=0
 {
   echo "Done"
   if $run_toplev; then
@@ -138,5 +180,10 @@ maya_runtime=0
     maya_runtime=$((maya_end - maya_start))
     echo
     echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+  if $run_pcm; then
+    pcm_runtime=$((pcm_end - pcm_start))
+    echo
+    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
   fi
 } > /local/data/results/done.log

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -12,17 +12,20 @@ fi
 # Parse tool selection arguments inside tmux
 run_toplev=false
 run_maya=false
+run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev) run_toplev=true ;;
     --maya)   run_maya=true ;;
-    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+    --pcm)    run_pcm=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya] [--pcm]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev && ! $run_maya; then
+if ! $run_toplev && ! $run_maya && ! $run_pcm; then
   run_toplev=true
   run_maya=true
+  run_pcm=true
 fi
 
 # Describe this workload
@@ -32,6 +35,7 @@ workload_desc="ID-20 (Speech Decoding)"
 tools_list=()
 $run_toplev && tools_list+=("toplev")
 $run_maya && tools_list+=("maya")
+$run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
 echo "Testing $workload_desc with tools: $tool_msg"
 for i in {10..1}; do
@@ -44,6 +48,8 @@ toplev_start=0
 toplev_end=0
 maya_start=0
 maya_end=0
+pcm_start=0
+pcm_end=0
 
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
@@ -168,6 +174,65 @@ if $run_maya; then
   maya_end=$(date +%s)
 fi
 
+if $run_pcm; then
+  pcm_start=$(date +%s)
+  sudo cset shield --reset
+  sudo modprobe msr
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm \
+      -csv=/local/data/results/id_20_pcm.csv \
+      0.5 -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_pcm.log 2>&1
+  '
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
+      -csv=/local/data/results/id_20_pcm_memory.csv \
+      0.5 -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_pcm_memory.log 2>&1
+  '
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
+      -p 0 -a 10 -b 20 -c 30 \
+      -csv=/local/data/results/id_20_pcm_power.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_pcm_power.log 2>&1
+  '
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_20_pcm_pcie.csv \
+      0.5 -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_pcm_pcie.log 2>&1
+  '
+  pcm_end=$(date +%s)
+fi
+
 ################################################################################
 
 if $run_maya; then
@@ -199,6 +264,7 @@ fi
 # Write completion file with runtimes
 toplev_runtime=0
 maya_runtime=0
+pcm_runtime=0
 {
   echo "Done"
   if $run_toplev; then
@@ -210,5 +276,10 @@ maya_runtime=0
     maya_runtime=$((maya_end - maya_start))
     echo
     echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+  if $run_pcm; then
+    pcm_runtime=$((pcm_end - pcm_start))
+    echo
+    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
   fi
 } > /local/data/results/done.log

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -12,17 +12,20 @@ fi
 # Parse tool selection arguments inside tmux
 run_toplev=false
 run_maya=false
+run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev) run_toplev=true ;;
     --maya)   run_maya=true ;;
-    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+    --pcm)    run_pcm=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya] [--pcm]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev && ! $run_maya; then
+if ! $run_toplev && ! $run_maya && ! $run_pcm; then
   run_toplev=true
   run_maya=true
+  run_pcm=true
 fi
 
 # Describe this workload
@@ -32,6 +35,7 @@ workload_desc="ID-20 3gram"
 tools_list=()
 $run_toplev && tools_list+=("toplev")
 $run_maya && tools_list+=("maya")
+$run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
 echo "Testing $workload_desc with tools: $tool_msg"
 for i in {10..1}; do
@@ -44,6 +48,8 @@ toplev_start=0
 toplev_end=0
 maya_start=0
 maya_end=0
+pcm_start=0
+pcm_end=0
 
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
@@ -195,6 +201,65 @@ kill "$MAYA_PID"
 maya_end=$(date +%s)
 fi
 
+if $run_pcm; then
+  pcm_start=$(date +%s)
+  sudo cset shield --reset
+  sudo modprobe msr
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm \
+      -csv=/local/data/results/id_20_3gram_pcm.csv \
+      0.5 -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_3gram_pcm.log 2>&1
+  '
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
+      -csv=/local/data/results/id_20_3gram_pcm_memory.csv \
+      0.5 -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_3gram_pcm_memory.log 2>&1
+  '
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
+      -p 0 -a 10 -b 20 -c 30 \
+      -csv=/local/data/results/id_20_3gram_pcm_power.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_3gram_pcm_power.log 2>&1
+  '
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_20_3gram_pcm_pcie.csv \
+      0.5 -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+      >>/local/data/results/id_20_3gram_pcm_pcie.log 2>&1
+  '
+  pcm_end=$(date +%s)
+fi
+
 ################################################################################
 if $run_maya; then
 ### 6. Convert Maya raw output files into CSV
@@ -224,6 +289,7 @@ fi
 # Write completion file with runtimes
 toplev_runtime=0
 maya_runtime=0
+pcm_runtime=0
 {
   echo "Done"
   if $run_toplev; then
@@ -235,5 +301,10 @@ maya_runtime=0
     maya_runtime=$((maya_end - maya_start))
     echo
     echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+  if $run_pcm; then
+    pcm_runtime=$((pcm_end - pcm_start))
+    echo
+    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
   fi
 } > /local/data/results/done.log

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -12,17 +12,20 @@ fi
 # Parse tool selection arguments inside tmux
 run_toplev=false
 run_maya=false
+run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev) run_toplev=true ;;
     --maya)   run_maya=true ;;
-    *) echo "Usage: $0 [--toplev] [--maya]" >&2; exit 1 ;;
+    --pcm)    run_pcm=true ;;
+    *) echo "Usage: $0 [--toplev] [--maya] [--pcm]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev && ! $run_maya; then
+if ! $run_toplev && ! $run_maya && ! $run_pcm; then
   run_toplev=true
   run_maya=true
+  run_pcm=true
 fi
 
 # Describe this workload
@@ -32,6 +35,7 @@ workload_desc="ID-3 (Compression)"
 tools_list=()
 $run_toplev && tools_list+=("toplev")
 $run_maya && tools_list+=("maya")
+$run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
 echo "Testing $workload_desc with tools: $tool_msg"
 for i in {10..1}; do
@@ -44,6 +48,8 @@ toplev_start=0
 toplev_end=0
 maya_start=0
 maya_end=0
+pcm_start=0
+pcm_end=0
 
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
@@ -103,6 +109,49 @@ if $run_maya; then
   maya_end=$(date +%s)
 fi
 
+if $run_pcm; then
+  pcm_start=$(date +%s)
+  sudo cset shield --reset
+  sudo modprobe msr
+  sudo bash -lc '
+    source /local/tools/compression_env/bin/activate
+    cd /local/bci_code/id_3/code
+    taskset -c 5 /local/tools/pcm/build/bin/pcm \
+      -csv=/local/data/results/id_3_pcm.csv \
+      0.5 -- \
+      taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac \
+    >>/local/data/results/id_3_pcm.log 2>&1
+  '
+  sudo bash -lc '
+    source /local/tools/compression_env/bin/activate
+    cd /local/bci_code/id_3/code
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
+      -csv=/local/data/results/id_3_pcm_memory.csv \
+      0.5 -- \
+      taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac \
+    >>/local/data/results/id_3_pcm_memory.log 2>&1
+  '
+  sudo bash -lc '
+    source /local/tools/compression_env/bin/activate
+    cd /local/bci_code/id_3/code
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
+      -p 0 -a 10 -b 20 -c 30 \
+      -csv=/local/data/results/id_3_pcm_power.csv -- \
+      taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac \
+    >>/local/data/results/id_3_pcm_power.log 2>&1
+  '
+  sudo bash -lc '
+    source /local/tools/compression_env/bin/activate
+    cd /local/bci_code/id_3/code
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_3_pcm_pcie.csv \
+      0.5 -- \
+      taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac \
+    >>/local/data/results/id_3_pcm_pcie.log 2>&1
+  '
+  pcm_end=$(date +%s)
+fi
+
 if $run_maya; then
 ### Convert Maya output to CSV
 echo "Converting id_3_aind_np1_flac_maya.txt → id_3_aind_np1_flac_maya.csv"
@@ -118,6 +167,7 @@ echo "aind-np1-flac profiling complete; results in /local/data/results/"
 # Write completion file with runtimes
 toplev_runtime=0
 maya_runtime=0
+pcm_runtime=0
 {
   echo "Done"
   if $run_toplev; then
@@ -129,5 +179,10 @@ maya_runtime=0
     maya_runtime=$((maya_end - maya_start))
     echo
     echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+  fi
+  if $run_pcm; then
+    pcm_runtime=$((pcm_end - pcm_start))
+    echo
+    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
   fi
 } > /local/data/results/done.log

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cpuset
+sudo apt-get install -y git build-essential cpuset cmake
 
 ################################################################################
 
@@ -171,6 +171,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 ################################################################################
 

--- a/scripts/startup_1.sh
+++ b/scripts/startup_1.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cpuset
+sudo apt-get install -y git build-essential cpuset cmake
 
 ################################################################################
 
@@ -171,6 +171,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 ################################################################################
 

--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -157,7 +157,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential ppp pptp-linux cpuset
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential ppp pptp-linux cpuset cmake
 
 ################################################################################
 
@@ -186,6 +186,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 ################################################################################
 

--- a/scripts/startup_20.sh
+++ b/scripts/startup_20.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential
+sudo apt-get install -y git build-essential cmake
 # Install necessary packages
 sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
 
@@ -173,6 +173,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 ################################################################################
 

--- a/scripts/startup_20_3gram.sh
+++ b/scripts/startup_20_3gram.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential
+sudo apt-get install -y git build-essential cmake
 # Install necessary packages
 sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
 
@@ -173,6 +173,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 ################################################################################
 

--- a/scripts/startup_20_5gram.sh
+++ b/scripts/startup_20_5gram.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential
+sudo apt-get install -y git build-essential cmake
 # Install necessary packages
 sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
 
@@ -173,6 +173,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 ################################################################################
 

--- a/scripts/startup_3.sh
+++ b/scripts/startup_3.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cpuset
+sudo apt-get install -y git build-essential cpuset cmake
 
 ################################################################################
 
@@ -171,6 +171,25 @@ sudo sysctl -w 'kernel.nmi_watchdog=0'
 sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-$(uname -r)
 # Download events (for toplev)
 sudo /local/tools/pmu-tools/event_download.py
+
+################################################################################
+
+### Installing intel-pcm
+
+# Move to the directory that holds all tool source
+cd /local/tools
+# Download pcm-repository in /local/tools
+git clone --recursive https://github.com/intel/pcm
+# Enter the repository
+cd pcm
+# Create a build directory
+mkdir build
+# Switch into build directory
+cd build
+# Configure the build with cmake
+cmake ..
+# Compile PCM using all cores
+cmake --build . --parallel
 
 
 ################################################################################


### PR DESCRIPTION
## Summary
- install intel-pcm in all startup scripts
- add optional `--pcm` mode to several run scripts
- run pcm tools for workloads after toplev/maya
- add comments for intel-pcm installation steps

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6855ce2ad75c832cbfc580086373cf10