### PR TITLE
Improve run logging and SCP debug

### DIFF
--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -197,10 +201,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_13/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_13_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_13_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_13_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -296,10 +300,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -321,10 +325,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -170,10 +174,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -170,10 +174,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -173,10 +177,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -9,6 +9,10 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$0" "$@"
 fi
 
+# Log to /local/logs/run.log
+mkdir -p /local/logs
+exec > >(tee -a /local/logs/run.log) 2>&1
+
 # Prompt for run ID to avoid overwriting results
 read -rp "Enter run number (1-3): " run_id
 if [[ ! $run_id =~ ^[1-3]$ ]]; then
@@ -199,10 +203,15 @@ client_ip=${SSH_CLIENT%% *}
 dest_user=${SCP_USER:-vic}
 dest_dir="/home/vic/Downloads/BCI/results/id_3/$run_id"
 if [[ -n $client_ip ]]; then
+  echo "Detected SSH client IP: $client_ip"
   echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'" && \
-  scp /local/data/results/id_3_* "$dest_user@$client_ip:$dest_dir/" || \
-  echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
+  echo "Running: scp -v /local/data/results/id_3_* \"$dest_user@$client_ip:$dest_dir/\""
+  if scp -v /local/data/results/id_3_* "$dest_user@$client_ip:$dest_dir/"; then
+    echo "SCP transfer succeeded"
+  else
+    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
+  fi
 else
   echo "SSH_CLIENT not set; skipping automatic SCP" >&2
 fi


### PR DESCRIPTION
## Summary
- log run scripts to `/local/logs/run.log`
- output more verbose information when copying results back to the user's computer

## Testing
- `shellcheck scripts/run_1.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_rnn.sh scripts/run_3.sh > /tmp/shellcheck.log`

------
https://chatgpt.com/codex/tasks/task_e_6855e32aea98832c9cec9fdd82c37e66