### PR TITLE
Remove scp steps from run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -199,20 +199,3 @@ pcm_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_1/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_1_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_1_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -196,20 +196,3 @@ pcm_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_13/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_13_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_13_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -295,20 +295,3 @@ pcm_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -320,20 +320,3 @@ pcm_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -169,20 +169,3 @@ maya_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -169,20 +169,3 @@ maya_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -172,20 +172,3 @@ maya_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_20/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_20_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_20_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -198,20 +198,3 @@ pcm_runtime=0
   fi
 } > /local/data/results/done.log
 
-# Attempt to copy results back to the invoking host
-client_ip=${SSH_CLIENT%% *}
-dest_user=${SCP_USER:-vic}
-dest_dir="/home/vic/Downloads/BCI/results/id_3/$run_id"
-if [[ -n $client_ip ]]; then
-  echo "Detected SSH client IP: $client_ip"
-  echo "Copying results to $dest_user@$client_ip:$dest_dir"
-  ssh "$dest_user@$client_ip" "mkdir -p '$dest_dir'"
-  echo "Running: scp -v /local/data/results/id_3_* \"$dest_user@$client_ip:$dest_dir/\""
-  if scp -v /local/data/results/id_3_* "$dest_user@$client_ip:$dest_dir/"; then
-    echo "SCP transfer succeeded"
-  else
-    echo "SCP transfer failed; ensure SSH access from this node to $client_ip" >&2
-  fi
-else
-  echo "SSH_CLIENT not set; skipping automatic SCP" >&2
-fi


### PR DESCRIPTION
## Summary
- remove automatic `scp` result transfer from all `run_*.sh` scripts

## Testing
- `bash -n scripts/run_*.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855e8400330832cab19efceda7cd093