### PR TITLE
Remove run number prompt from run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -13,12 +13,6 @@ fi
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-# Prompt for run ID to avoid overwriting results
-read -rp "Enter run number (1-3): " run_id
-if [[ ! $run_id =~ ^[1-3]$ ]]; then
-  echo "Run number must be 1, 2, or 3" >&2
-  exit 1
-fi
 
 # Parse tool selection arguments inside tmux
 run_toplev=false


### PR DESCRIPTION
## Summary
- eliminate run number prompt from all run scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*

------
https://chatgpt.com/codex/tasks/task_e_685720017520832c9c8d42a23ece738b