### PR TITLE
Instrument decoder initialization

### DIFF
--- a/id_20/README
+++ b/id_20/README
@@ -11,6 +11,7 @@ PHASE <TAG> <START|END> ABS:<seconds>.<micros> REL:<seconds>.<micros>
 The main phases are:
 
 - **Setup (SETUP)** – parse command‑line arguments and load all necessary models or decoders before processing begins.
+- **Decoder Initialization (DECODER_INIT)** – load the WFST and construct the decoder.
 - **Inference (INFER)** – perform the forward pass of the recurrent neural network over the test dataset, producing logits for each sample.
 - **Save Results (SAVE)** – serialize intermediate outputs such as logits or n‑best lists to disk for later use.
 - **Load Results (LOAD)** – read previously saved results so that downstream decoding or rescoring can resume without repeating earlier steps.

--- a/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py
+++ b/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py
@@ -345,7 +345,10 @@ def cer_pre_opt(nbestOutputs, inferenceOut):
         
 
 
+
+log_phase('DECODER_INIT','START')
 ngramDecoder = PyKaldiDecoder(lmDir, acoustic_scale=0.5, nbest=10)
+log_phase('DECODER_INIT','END')
 
 # read rnn_outputs and nbest_outputs if doing llm separately
 #with open("rnn_results.pkl", "rb") as f:


### PR DESCRIPTION
## Summary
- measure WFST decoder loading in `wfst_model_run.py`
- document the new `DECODER_INIT` phase in ID‑20 README

## Testing
- `python -m py_compile id_20/code/neural_seq_decoder/scripts/wfst_model_run.py`
- `python -m py_compile id_20/code/neural_seq_decoder/scripts/llm_model_run.py id_20/code/neural_seq_decoder/scripts/rnn_run.py`


------
https://chatgpt.com/codex/tasks/task_e_685731a629d0832ca1e4927344def02f