### PR TITLE
Print timestamp before executing workloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ tools/maya/            – microarchitectural profiler (C++)
 4. **Light testing** – unit‑test pure Python utilities (e.g. id\_3/code/utils.py).
 5. **Style clean‑up** – apply clang‑format or black where appropriate.
 
+6. **Timestamp logging** – after the 10-second countdown, each run script must print `Experiment started at: YYYY-MM-DD - hh:mm` to record the start time.
 ## Things Codex MUST NOT Do
 
 * Try to run full workloads locally – they assume CloudLab, GPUs, or MATLAB.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -269,26 +271,6 @@ echo "All done. Results are in /local/data/results/"
 ### 9. Write completion file with runtimes
 ################################################################################
 
-toplev_runtime=0
-maya_runtime=0
-pcm_runtime=0
-pcm_memory_runtime=0
-pcm_power_runtime=0
-pcm_pcie_runtime=0
-{
-  echo "Done"
-  if $run_toplev; then
-    toplev_runtime=$((toplev_end - toplev_start))
-    echo
-    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
-  fi
-  if $run_maya; then
-    maya_runtime=$((maya_end - maya_start))
-    echo
-    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
-  fi
-  if $run_pcm; then
-    pcm_runtime=$((pcm_end - pcm_start))
 {
   echo "Done"
   if $run_toplev; then

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -269,26 +271,6 @@ echo "All done. Results are in /local/data/results/"
 ### 9. Write completion file with runtimes
 ################################################################################
 
-toplev_runtime=0
-maya_runtime=0
-pcm_runtime=0
-pcm_memory_runtime=0
-pcm_power_runtime=0
-pcm_pcie_runtime=0
-{
-  echo "Done"
-  if $run_toplev; then
-    toplev_runtime=$((toplev_end - toplev_start))
-    echo
-    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
-  fi
-  if $run_maya; then
-    maya_runtime=$((maya_end - maya_start))
-    echo
-    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
-  fi
-  if $run_pcm; then
-    pcm_runtime=$((pcm_end - pcm_start))
 {
   echo "Done"
   if $run_toplev; then

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -271,28 +273,6 @@ echo "All done. Results are in /local/data/results/"
 ################################################################################
 ### 9. Write completion file with runtimes
 ################################################################################
-
-toplev_runtime=0
-maya_runtime=0
-pcm_runtime=0
-pcm_memory_runtime=0
-pcm_power_runtime=0
-pcm_pcie_runtime=0
-{
-  echo "Done"
-  if $run_toplev; then
-    toplev_runtime=$((toplev_end - toplev_start))
-    echo
-    echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")"
-  fi
-  if $run_maya; then
-    maya_runtime=$((maya_end - maya_start))
-    echo
-    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
-  fi
-  if $run_pcm; then
-    pcm_runtime=$((pcm_end - pcm_start))
-    pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
 {
   echo "Done"
   if $run_toplev; then

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -48,6 +48,8 @@ for i in {10..1}; do
   sleep 1
 done
 
+echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0


### PR DESCRIPTION
## Summary
- show timestamp after tmux startup and countdown
- fix malformed end sections in 3gram run scripts
- document timestamp requirement in `AGENTS.md`

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_3.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860c8e3b30c832c8cef95a1ed001883