### PR TITLE
Fix runtime quoting across run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -98,7 +98,7 @@ if $run_toplev; then
   '
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
 fi
 
@@ -126,7 +126,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
 
@@ -168,7 +168,7 @@ if $run_pcm; then
   '
   pcm_end=$(date +%s)
   pcm_runtime=$((pcm_end - pcm_start))
-  echo "PCM runtime:    $(secs_to_dhm \"$pcm_runtime\")" \
+  echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
 fi
 

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -103,7 +103,7 @@ if $run_toplev; then
   ' &> /local/data/results/id_13_toplev.log
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
 fi
 
@@ -132,7 +132,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
 
@@ -175,7 +175,7 @@ if $run_pcm; then
   pcm_end=$(date +%s)
   pcm_runtime=$((pcm_end - pcm_start))
   {
-    echo "PCM runtime:    $(secs_to_dhm \"$pcm_runtime\")"
+    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
   } > /local/data/results/done_pcm.log
 fi
 

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -131,7 +131,7 @@ if $run_toplev; then
   '
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
 fi
 
@@ -192,7 +192,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
 
@@ -291,10 +291,10 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:         $(secs_to_dhm \"$pcm_runtime\")"
-    echo "PCM-memory runtime:  $(secs_to_dhm \"$pcm_memory_runtime\")"
-    echo "PCM-power runtime:   $(secs_to_dhm \"$pcm_power_runtime\")"
-    echo "PCM-pcie runtime:    $(secs_to_dhm \"$pcm_pcie_runtime\")"
+    echo "PCM runtime:         $(secs_to_dhm "$pcm_runtime")"
+    echo "PCM-memory runtime:  $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
+    echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_pcm.log
 fi
 

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -141,7 +141,7 @@ sudo -E cset shield --exec -- bash -lc '
 ' &> /local/data/results/id_20_3gram_llm_toplev.log
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
 fi
 
@@ -218,7 +218,7 @@ kill "$MAYA_PID"
 '
 maya_end=$(date +%s)
 maya_runtime=$((maya_end - maya_start))
-echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
   > /local/data/results/done_maya.log
 fi
 
@@ -317,10 +317,10 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:         $(secs_to_dhm \"$pcm_runtime\")"
-    echo "PCM-memory runtime:  $(secs_to_dhm \"$pcm_memory_runtime\")"
-    echo "PCM-power runtime:   $(secs_to_dhm \"$pcm_power_runtime\")"
-    echo "PCM-pcie runtime:    $(secs_to_dhm \"$pcm_pcie_runtime\")"
+    echo "PCM runtime:         $(secs_to_dhm "$pcm_runtime")"
+    echo "PCM-memory runtime:  $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
+    echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_pcm.log
 fi
 

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -112,7 +112,7 @@ if $run_toplev; then
   ' &> /local/data/results/id_20_3gram_llm_toplev.log
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_llm_toplev.log
 fi
 
@@ -145,7 +145,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_llm_maya.log
 fi
 
@@ -244,10 +244,10 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:         $(secs_to_dhm \"$pcm_runtime\")"
-    echo "PCM-memory runtime:  $(secs_to_dhm \"$pcm_memory_runtime\")"
-    echo "PCM-power runtime:   $(secs_to_dhm \"$pcm_power_runtime\")"
-    echo "PCM-pcie runtime:    $(secs_to_dhm \"$pcm_pcie_runtime\")"
+    echo "PCM runtime:         $(secs_to_dhm "$pcm_runtime")"
+    echo "PCM-memory runtime:  $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
+    echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_llm_pcm.log
 fi
 

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -112,7 +112,7 @@ if $run_toplev; then
   ' &> /local/data/results/id_20_3gram_lm_toplev.log
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_lm_toplev.log
 fi
 
@@ -145,7 +145,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_lm_maya.log
 fi
 
@@ -244,10 +244,10 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:         $(secs_to_dhm \"$pcm_runtime\")"
-    echo "PCM-memory runtime:  $(secs_to_dhm \"$pcm_memory_runtime\")"
-    echo "PCM-power runtime:   $(secs_to_dhm \"$pcm_power_runtime\")"
-    echo "PCM-pcie runtime:    $(secs_to_dhm \"$pcm_pcie_runtime\")"
+    echo "PCM runtime:         $(secs_to_dhm "$pcm_runtime")"
+    echo "PCM-memory runtime:  $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
+    echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_lm_pcm.log
 fi
 

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -113,7 +113,7 @@ toplev_end=$(date +%s)
   ' &> /local/data/results/id_20_3gram_rnn_toplev.log
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_rnn_toplev.log
 fi
 
@@ -148,7 +148,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_rnn_maya.log
 fi
 
@@ -247,10 +247,10 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:         $(secs_to_dhm \"$pcm_runtime\")"
-    echo "PCM-memory runtime:  $(secs_to_dhm \"$pcm_memory_runtime\")"
-    echo "PCM-power runtime:   $(secs_to_dhm \"$pcm_power_runtime\")"
-    echo "PCM-pcie runtime:    $(secs_to_dhm \"$pcm_pcie_runtime\")"
+    echo "PCM runtime:         $(secs_to_dhm "$pcm_runtime")"
+    echo "PCM-memory runtime:  $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
+    echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_rnn_pcm.log
 fi
 

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -110,7 +110,7 @@ if $run_toplev; then
   ' &>  /local/data/results/id_3_toplev.log
   toplev_end=$(date +%s)
   toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm \"$toplev_runtime\")" \
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
 fi
 
@@ -138,7 +138,7 @@ if $run_maya; then
   '
   maya_end=$(date +%s)
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm \"$maya_runtime\")" \
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
 
@@ -201,11 +201,11 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:    $(secs_to_dhm \"$pcm_runtime\")"
-    echo "pcm:           $(secs_to_dhm \"$pcm_gen_runtime\")"
-    echo "pcm-memory:    $(secs_to_dhm \"$pcm_mem_runtime\")"
-    echo "pcm-power:     $(secs_to_dhm \"$pcm_power_runtime\")"
-    echo "pcm-pcie:      $(secs_to_dhm \"$pcm_pcie_runtime\")"
+    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
+    echo "pcm:           $(secs_to_dhm "$pcm_gen_runtime")"
+    echo "pcm-memory:    $(secs_to_dhm "$pcm_mem_runtime")"
+    echo "pcm-power:     $(secs_to_dhm "$pcm_power_runtime")"
+    echo "pcm-pcie:      $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_pcm.log
 fi
 


### PR DESCRIPTION
## Summary
- correct variable quoting in runtime logs across all `run_*.sh` scripts

## Testing
- `shellcheck scripts/run_1.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_rnn.sh scripts/run_3.sh`
- `bash -n scripts/run_1.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_rnn.sh scripts/run_3.sh`

------
https://chatgpt.com/codex/tasks/task_e_68619aa2f408832cbf39f93c6fc192c4