### PR TITLE
Use Toronto time for run logs

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -48,7 +48,7 @@ for i in {10..1}; do
   sleep 1
 done
 
-echo "Experiment started at: $(date '+%Y-%m-%d - %H:%M')"
+echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Initialize timing variables
 toplev_start=0


### PR DESCRIPTION
## Summary
- adjust run scripts to show start time in Toronto (America/Toronto)

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_3.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_6861b5fa8b4c832caf8b9720be89e88f