### PR TITLE
Add short/long flags to ID-20 3gram scripts

### DIFF
--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -27,7 +27,21 @@ while [[ $# -gt 0 ]]; do
     --toplev-memory)     run_toplev_memory=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm]" >&2; exit 1 ;;
+    --short)
+      run_toplev=false
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    --long)
+      run_toplev=true
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -27,7 +27,21 @@ while [[ $# -gt 0 ]]; do
     --toplev-memory)     run_toplev_memory=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm]" >&2; exit 1 ;;
+    --short)
+      run_toplev=false
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    --long)
+      run_toplev=true
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -27,7 +27,21 @@ while [[ $# -gt 0 ]]; do
     --toplev-memory)     run_toplev_memory=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm]" >&2; exit 1 ;;
+    --short)
+      run_toplev=false
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    --long)
+      run_toplev=true
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -27,7 +27,21 @@ while [[ $# -gt 0 ]]; do
     --toplev-memory)     run_toplev_memory=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm]" >&2; exit 1 ;;
+    --short)
+      run_toplev=false
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    --long)
+      run_toplev=true
+      run_toplev_execution=true
+      run_toplev_memory=true
+      run_maya=true
+      run_pcm=true
+      ;;
+    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-memory] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done


### PR DESCRIPTION
## Summary
- support `--short` and `--long` in the ID-20 3gram scripts

## Testing
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_6869745bd064832c825a79969d832b37