### PR TITLE
Fix experiment order in ID-20 run scripts

### DIFF
--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -123,118 +123,6 @@ source /local/tools/bci_env/bin/activate
 # Export PYTHONPATH
 export PYTHONPATH=$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:$PYTHONPATH
 
-if $run_toplev; then
-  toplev_start=$(date +%s)
-  ### Toplev profiling
-
-  # Run the RNN script
-  sudo -E cset shield --exec -- sh -c '
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l6 -I 500 --no-multiplex --all -x, \
-      -o /local/data/results/id_20_rnn_toplev.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/ \
-          >> /local/data/results/id_20_rnn_toplev.log 2>&1
-  '
-
-  # Run the LM script
-  sudo -E cset shield --exec -- sh -c '
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l6 -I 500 --no-multiplex --all -x, \
-      -o /local/data/results/id_20_lm_toplev.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-          --lmDir=/local/data/languageModel/ \
-          >> /local/data/results/id_20_lm_toplev.log 2>&1
-  '
-
-  # Run the LLM script
-  sudo -E cset shield --exec -- sh -c '
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l6 -I 500 --no-multiplex --all -x, \
-      -o /local/data/results/id_20_llm_toplev.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          >> /local/data/results/id_20_llm_toplev.log 2>&1
-  '
-  toplev_end=$(date +%s)
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_toplev.log
-fi
-
-if $run_toplev_execution; then
-  toplev_execution_start=$(date +%s)
-  # RNN script
-  sudo -E cset shield --exec -- sh -c '
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l1 -I 500 -v -x, \
-      -o /local/data/results/id_20_rnn_toplev_execution.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/ \
-          >> /local/data/results/id_20_rnn_toplev_execution.log 2>&1
-  '
-
-  # LM script
-  sudo -E cset shield --exec -- sh -c '
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l1 -I 500 -v -x, \
-      -o /local/data/results/id_20_lm_toplev_execution.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-          --lmDir=/local/data/languageModel/ \
-          >> /local/data/results/id_20_lm_toplev_execution.log 2>&1
-  '
-
-  # LLM script
-  sudo -E cset shield --exec -- sh -c '
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l1 -I 500 -v -x, \
-      -o /local/data/results/id_20_llm_toplev_execution.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          >> /local/data/results/id_20_llm_toplev_execution.log 2>&1
-  '
-  toplev_execution_end=$(date +%s)
-  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
-  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
-    > /local/data/results/done_toplev_execution.log
-fi
-
-if $run_toplev_memory; then
-  toplev_memory_start=$(date +%s)
-  # RNN script
-  sudo -E cset shield --exec -- sh -c "
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_20_rnn_toplev_memory.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/ \
-          >> /local/data/results/id_20_rnn_toplev_memory.log 2>&1
-  "
-
-  # LM script
-  sudo -E cset shield --exec -- sh -c "
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_20_lm_toplev_memory.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-          --lmDir=/local/data/languageModel/ \
-          >> /local/data/results/id_20_lm_toplev_memory.log 2>&1
-  "
-
-  # LLM script
-  sudo -E cset shield --exec -- sh -c "
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_20_llm_toplev_memory.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          >> /local/data/results/id_20_llm_toplev_memory.log 2>&1
-  "
-  toplev_memory_end=$(date +%s)
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_toplev_memory.log
-fi
 
 ################################################################################
 ### Maya profiling
@@ -399,6 +287,118 @@ if $run_pcm; then
   } > /local/data/results/done_pcm.log
 fi
 
+if $run_toplev_execution; then
+  toplev_execution_start=$(date +%s)
+  # RNN script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l1 -I 500 -v -x, \
+      -o /local/data/results/id_20_rnn_toplev_execution.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/ \
+          >> /local/data/results/id_20_rnn_toplev_execution.log 2>&1
+  '
+
+  # LM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l1 -I 500 -v -x, \
+      -o /local/data/results/id_20_lm_toplev_execution.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          >> /local/data/results/id_20_lm_toplev_execution.log 2>&1
+  '
+
+  # LLM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l1 -I 500 -v -x, \
+      -o /local/data/results/id_20_llm_toplev_execution.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          >> /local/data/results/id_20_llm_toplev_execution.log 2>&1
+  '
+  toplev_execution_end=$(date +%s)
+  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
+  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
+    > /local/data/results/done_toplev_execution.log
+fi
+
+if $run_toplev_memory; then
+  toplev_memory_start=$(date +%s)
+  # RNN script
+  sudo -E cset shield --exec -- sh -c "
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+      -o /local/data/results/id_20_rnn_toplev_memory.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/ \
+          >> /local/data/results/id_20_rnn_toplev_memory.log 2>&1
+  "
+
+  # LM script
+  sudo -E cset shield --exec -- sh -c "
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+      -o /local/data/results/id_20_lm_toplev_memory.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          >> /local/data/results/id_20_lm_toplev_memory.log 2>&1
+  "
+
+  # LLM script
+  sudo -E cset shield --exec -- sh -c "
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+      -o /local/data/results/id_20_llm_toplev_memory.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          >> /local/data/results/id_20_llm_toplev_memory.log 2>&1
+  "
+  toplev_memory_end=$(date +%s)
+  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
+  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
+    > /local/data/results/done_toplev_memory.log
+fi
+
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  ### Toplev profiling
+
+  # Run the RNN script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_20_rnn_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/ \
+          >> /local/data/results/id_20_rnn_toplev.log 2>&1
+  '
+
+  # Run the LM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_20_lm_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          >> /local/data/results/id_20_lm_toplev.log 2>&1
+  '
+
+  # Run the LLM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 --no-multiplex --all -x, \
+      -o /local/data/results/id_20_llm_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          >> /local/data/results/id_20_llm_toplev.log 2>&1
+  '
+  toplev_end=$(date +%s)
+  toplev_runtime=$((toplev_end - toplev_start))
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
+    > /local/data/results/done_toplev.log
+fi
 ################################################################################
 ### Convert Maya raw output to CSV
 ################################################################################

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -117,161 +117,8 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Toplev profiling
 ################################################################################
-
-# Run the RNN script under toplev (toplev on CPU 5, workload on CPU 6)
-if $run_toplev; then
-  toplev_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l6 -I 500 -v --no-multiplex --all -x, \
-      -o /local/data/results/id_20_3gram_rnn_toplev.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/
-  ' &> /local/data/results/id_20_3gram_rnn_toplev.log
-
-# Run the LM script under toplev (toplev on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_lm_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-        --lmDir=/local/data/languageModel/ \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-' &> /local/data/results/id_20_3gram_lm_toplev.log
-
-# Run the LLM script under toplev (toplev on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-' &> /local/data/results/id_20_3gram_llm_toplev.log
-  toplev_end=$(date +%s)
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_toplev.log
-fi
-
-if $run_toplev_execution; then
-  toplev_execution_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l1 -I 500 -v -x, \
-      -o /local/data/results/id_20_3gram_rnn_toplev_execution.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/
-  ' &> /local/data/results/id_20_3gram_rnn_toplev_execution.log
-
-  sudo -E cset shield --exec -- bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l1 -I 500 -v -x, \
-      -o /local/data/results/id_20_3gram_lm_toplev_execution.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-          --lmDir=/local/data/languageModel/ \
-          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-  ' &> /local/data/results/id_20_3gram_lm_toplev_execution.log
-
-  sudo -E cset shield --exec -- bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l1 -I 500 -v -x, \
-      -o /local/data/results/id_20_3gram_llm_toplev_execution.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  ' &> /local/data/results/id_20_3gram_llm_toplev_execution.log
-  toplev_execution_end=$(date +%s)
-  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
-  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
-    > /local/data/results/done_toplev_execution.log
-fi
-
-if $run_toplev_memory; then
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-    . path.sh
-    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_20_3gram_rnn_toplev_memory.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/
-  " &> /local/data/results/id_20_3gram_rnn_toplev_memory.log
-
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-    . path.sh
-    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_20_3gram_lm_toplev_memory.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-          --lmDir=/local/data/languageModel/ \
-          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-  " &> /local/data/results/id_20_3gram_lm_toplev_memory.log
-
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-    . path.sh
-    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_20_3gram_llm_toplev_memory.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_toplev_memory.log
-fi
-
-################################################################################
-### 5. Maya profiling
+### 4. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -348,7 +195,7 @@ echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
 fi
 
 ################################################################################
-### 6. PCM profiling
+### 5. PCM profiling
 ################################################################################
 
 if $run_pcm; then
@@ -448,9 +295,167 @@ if $run_pcm; then
     echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_pcm.log
 fi
+################################################################################
+### 6. Toplev execution profiling
+################################################################################
+
+if $run_toplev_execution; then
+  toplev_execution_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l1 -I 500 -v -x, \
+      -o /local/data/results/id_20_3gram_rnn_toplev_execution.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/
+  ' &> /local/data/results/id_20_3gram_rnn_toplev_execution.log
+
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l1 -I 500 -v -x, \
+      -o /local/data/results/id_20_3gram_lm_toplev_execution.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  ' &> /local/data/results/id_20_3gram_lm_toplev_execution.log
+
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l1 -I 500 -v -x, \
+      -o /local/data/results/id_20_3gram_llm_toplev_execution.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  ' &> /local/data/results/id_20_3gram_llm_toplev_execution.log
+  toplev_execution_end=$(date +%s)
+  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
+  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
+    > /local/data/results/done_toplev_execution.log
+fi
 
 ################################################################################
-### 7. Convert Maya raw output files into CSV
+### 7. Toplev memory profiling
+################################################################################
+
+if $run_toplev_memory; then
+  toplev_memory_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc "
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
+    . path.sh
+    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+      -o /local/data/results/id_20_3gram_rnn_toplev_memory.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/
+  " &> /local/data/results/id_20_3gram_rnn_toplev_memory.log
+
+  sudo -E cset shield --exec -- bash -lc "
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
+    . path.sh
+    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+      -o /local/data/results/id_20_3gram_lm_toplev_memory.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  " &> /local/data/results/id_20_3gram_lm_toplev_memory.log
+
+  sudo -E cset shield --exec -- bash -lc "
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
+    . path.sh
+    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+      -o /local/data/results/id_20_3gram_llm_toplev_memory.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
+  toplev_memory_end=$(date +%s)
+  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
+  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
+    > /local/data/results/done_toplev_memory.log
+fi
+
+################################################################################
+### 8. Toplev profiling
+################################################################################
+
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 -v --no-multiplex --all -x, \
+      -o /local/data/results/id_20_3gram_rnn_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/
+  ' &> /local/data/results/id_20_3gram_rnn_toplev.log
+
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 -v --no-multiplex --all -x, \
+      -o /local/data/results/id_20_3gram_lm_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  ' &> /local/data/results/id_20_3gram_lm_toplev.log
+
+  sudo -E cset shield --exec -- bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l6 -I 500 -v --no-multiplex --all -x, \
+      -o /local/data/results/id_20_3gram_llm_toplev.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  ' &> /local/data/results/id_20_3gram_llm_toplev.log
+  toplev_end=$(date +%s)
+  toplev_runtime=$((toplev_end - toplev_start))
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
+    > /local/data/results/done_toplev.log
+fi
+
+################################################################################
+### 9. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -471,12 +476,12 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 8. Signal completion for tmux monitoring
+### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 ################################################################################
-### 9. Write completion file with runtimes
+### 11. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -117,76 +117,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  toplev_start=$(date +%s)
-
-  # Run the LLM script under toplev (toplev on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  ' &> /local/data/results/id_20_3gram_llm_toplev.log
-  toplev_end=$(date +%s)
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_llm_toplev.log
-fi
-
-if $run_toplev_execution; then
-  toplev_execution_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l1 -I 500 -v -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev_execution.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  ' &> /local/data/results/id_20_3gram_llm_toplev_execution.log
-  toplev_execution_end=$(date +%s)
-  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
-  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
-    > /local/data/results/done_llm_toplev_execution.log
-fi
-
-if $run_toplev_memory; then
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev_memory.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_llm_toplev_memory.log
-fi
-
-################################################################################
-### 5. Maya profiling
+### 4. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -219,7 +150,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. PCM profiling
+### 5. PCM profiling
 ################################################################################
 
 if $run_pcm; then
@@ -321,7 +252,81 @@ if $run_pcm; then
 fi
 
 ################################################################################
-### 7. Convert Maya raw output files into CSV
+### 6. Toplev execution profiling
+################################################################################
+
+if $run_toplev_execution; then
+  toplev_execution_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l1 -I 500 -v -x, \
+    -o /local/data/results/id_20_3gram_llm_toplev_execution.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  ' &> /local/data/results/id_20_3gram_llm_toplev_execution.log
+  toplev_execution_end=$(date +%s)
+  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
+  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
+    > /local/data/results/done_llm_toplev_execution.log
+fi
+
+################################################################################
+### 7. Toplev memory profiling
+################################################################################
+
+if $run_toplev_memory; then
+  toplev_memory_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc "
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
+  . path.sh
+  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+    -o /local/data/results/id_20_3gram_llm_toplev_memory.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
+  toplev_memory_end=$(date +%s)
+  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
+  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
+    > /local/data/results/done_llm_toplev_memory.log
+fi
+
+################################################################################
+### 8. Toplev profiling
+################################################################################
+
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l6 -I 500 -v --no-multiplex --all -x, \
+    -o /local/data/results/id_20_3gram_llm_toplev.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  ' &> /local/data/results/id_20_3gram_llm_toplev.log
+  toplev_end=$(date +%s)
+  toplev_runtime=$((toplev_end - toplev_start))
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
+    > /local/data/results/done_llm_toplev.log
+fi
+################################################################################
+### 9. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -332,12 +337,12 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 8. Signal completion for tmux monitoring
+### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 ################################################################################
-### 9. Write completion file with runtimes
+### 11. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -117,76 +117,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  toplev_start=$(date +%s)
-
-  # Run the LM script under toplev (toplev on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_lm_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-        --lmDir=/local/data/languageModel/ \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-  ' &> /local/data/results/id_20_3gram_lm_toplev.log
-  toplev_end=$(date +%s)
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_lm_toplev.log
-fi
-
-if $run_toplev_execution; then
-  toplev_execution_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l1 -I 500 -v -x, \
-    -o /local/data/results/id_20_3gram_lm_toplev_execution.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-        --lmDir=/local/data/languageModel/ \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-  ' &> /local/data/results/id_20_3gram_lm_toplev_execution.log
-  toplev_execution_end=$(date +%s)
-  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
-  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
-    > /local/data/results/done_lm_toplev_execution.log
-fi
-
-if $run_toplev_memory; then
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-    -o /local/data/results/id_20_3gram_lm_toplev_memory.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-        --lmDir=/local/data/languageModel/ \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
-  " &> /local/data/results/id_20_3gram_lm_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_lm_toplev_memory.log
-fi
-
-################################################################################
-### 5. Maya profiling
+### 4. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -219,7 +150,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. PCM profiling
+### 5. PCM profiling
 ################################################################################
 
 if $run_pcm; then
@@ -321,7 +252,81 @@ if $run_pcm; then
 fi
 
 ################################################################################
-### 7. Convert Maya raw output files into CSV
+### 6. Toplev execution profiling
+################################################################################
+
+if $run_toplev_execution; then
+  toplev_execution_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l1 -I 500 -v -x, \
+    -o /local/data/results/id_20_3gram_lm_toplev_execution.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+        --lmDir=/local/data/languageModel/ \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  ' &> /local/data/results/id_20_3gram_lm_toplev_execution.log
+  toplev_execution_end=$(date +%s)
+  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
+  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
+    > /local/data/results/done_lm_toplev_execution.log
+fi
+
+################################################################################
+### 7. Toplev memory profiling
+################################################################################
+
+if $run_toplev_memory; then
+  toplev_memory_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc "
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
+  . path.sh
+  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+    -o /local/data/results/id_20_3gram_lm_toplev_memory.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+        --lmDir=/local/data/languageModel/ \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  " &> /local/data/results/id_20_3gram_lm_toplev_memory.log
+  toplev_memory_end=$(date +%s)
+  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
+  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
+    > /local/data/results/done_lm_toplev_memory.log
+fi
+
+################################################################################
+### 8. Toplev profiling
+################################################################################
+
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l6 -I 500 -v --no-multiplex --all -x, \
+    -o /local/data/results/id_20_3gram_lm_toplev.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+        --lmDir=/local/data/languageModel/ \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  ' &> /local/data/results/id_20_3gram_lm_toplev.log
+  toplev_end=$(date +%s)
+  toplev_runtime=$((toplev_end - toplev_start))
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
+    > /local/data/results/done_lm_toplev.log
+fi
+################################################################################
+### 9. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -332,12 +337,12 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 8. Signal completion for tmux monitoring
+### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 ################################################################################
-### 9. Write completion file with runtimes
+### 11. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -117,77 +117,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  toplev_start=$(date +%s)
-
-  # Run the RNN script under toplev (toplev on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-toplev_end=$(date +%s)
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  ' &> /local/data/results/id_20_3gram_rnn_toplev.log
-  toplev_end=$(date +%s)
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_rnn_toplev.log
-fi
-
-if $run_toplev_execution; then
-  toplev_execution_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l1 -I 500 -v -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev_execution.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  ' &> /local/data/results/id_20_3gram_rnn_toplev_execution.log
-  toplev_execution_end=$(date +%s)
-  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
-  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
-    > /local/data/results/done_rnn_toplev_execution.log
-fi
-
-if $run_toplev_memory; then
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev_memory.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  " &> /local/data/results/id_20_3gram_rnn_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_rnn_toplev_memory.log
-fi
-
-################################################################################
-### 5. Maya profiling
+### 4. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -222,7 +152,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. PCM profiling
+### 5. PCM profiling
 ################################################################################
 
 if $run_pcm; then
@@ -324,7 +254,82 @@ if $run_pcm; then
 fi
 
 ################################################################################
-### 7. Convert Maya raw output files into CSV
+### 6. Toplev execution profiling
+################################################################################
+
+if $run_toplev_execution; then
+  toplev_execution_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l1 -I 500 -v -x, \
+    -o /local/data/results/id_20_3gram_rnn_toplev_execution.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/
+  ' &> /local/data/results/id_20_3gram_rnn_toplev_execution.log
+  toplev_execution_end=$(date +%s)
+  toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
+  echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
+    > /local/data/results/done_rnn_toplev_execution.log
+fi
+
+################################################################################
+### 7. Toplev memory profiling
+################################################################################
+
+if $run_toplev_memory; then
+  toplev_memory_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc "
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
+  . path.sh
+  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
+    -o /local/data/results/id_20_3gram_rnn_toplev_memory.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/
+  " &> /local/data/results/id_20_3gram_rnn_toplev_memory.log
+  toplev_memory_end=$(date +%s)
+  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
+  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
+    > /local/data/results/done_rnn_toplev_memory.log
+fi
+
+################################################################################
+### 8. Toplev profiling
+################################################################################
+
+if $run_toplev; then
+  toplev_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+toplev_end=$(date +%s)
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l6 -I 500 -v --no-multiplex --all -x, \
+    -o /local/data/results/id_20_3gram_rnn_toplev.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/
+  ' &> /local/data/results/id_20_3gram_rnn_toplev.log
+  toplev_end=$(date +%s)
+  toplev_runtime=$((toplev_end - toplev_start))
+  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
+    > /local/data/results/done_rnn_toplev.log
+fi
+################################################################################
+### 9. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -335,12 +340,12 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 8. Signal completion for tmux monitoring
+### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 ################################################################################
-### 9. Write completion file with runtimes
+### 11. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"


### PR DESCRIPTION
## Summary
- reorder ID‑20 run scripts so profiling happens in Maya → PCM → Toplev order
- add step numbers for clarity

## Testing
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_686978836020832cb7d0fd292dd1965c