### PR TITLE
Fix log consolidation for any tool combination

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -99,6 +99,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Prepare placeholder logs for any disabled tools so that log consolidation
+# works regardless of the selected combination.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -263,26 +273,17 @@ echo "All done. Results are in /local/data/results/"
 ################################################################################
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_pcm.log
-  fi
+  for log in \
+      done_toplev.log \
+      done_toplev_execution.log \
+      done_toplev_memory.log \
+      done_maya.log \
+      done_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev.log \

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -99,6 +99,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Prepare placeholder logs for any disabled tools so that later consolidation
+# yields a consistent done.log.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -275,26 +285,17 @@ echo "All done. Results are in /local/data/results/"
 
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_pcm.log
-  fi
+  for log in \
+      done_toplev.log \
+      done_toplev_execution.log \
+      done_toplev_memory.log \
+      done_maya.log \
+      done_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev.log \

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -105,6 +105,16 @@ cd /local; mkdir -p data; cd data; mkdir -p results;
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Create placeholder logs for any tools that are disabled so that results
+# aggregation behaves consistently across run configurations.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -443,26 +453,17 @@ echo "All done. Results are in /local/data/results/"
 
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_pcm.log
-  fi
+  for log in \
+      done_toplev.log \
+      done_toplev_execution.log \
+      done_toplev_memory.log \
+      done_maya.log \
+      done_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev.log \

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -105,6 +105,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Create placeholder logs for each disabled tool so that the final aggregation
+# step can handle every combination of selected programs.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -486,26 +496,17 @@ echo "All done. Results are in /local/data/results/"
 
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_pcm.log
-  fi
+  for log in \
+      done_toplev.log \
+      done_toplev_execution.log \
+      done_toplev_memory.log \
+      done_maya.log \
+      done_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev.log \

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -105,6 +105,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Prepare placeholder logs for any disabled tool so that done.log contains an
+# entry for every possible stage.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_llm_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_llm_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_llm_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_llm_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_llm_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -347,26 +357,17 @@ echo "All done. Results are in /local/data/results/"
 
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_llm_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_llm_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_llm_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_llm_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_llm_pcm.log
-  fi
+  for log in \
+      done_llm_toplev.log \
+      done_llm_toplev_execution.log \
+      done_llm_toplev_memory.log \
+      done_llm_maya.log \
+      done_llm_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done_llm.log
 
 rm -f /local/data/results/done_llm_toplev.log \

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -105,6 +105,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Create placeholder logs for tools that aren't selected so that the final
+# summary always lists every stage.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_lm_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_lm_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_lm_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_lm_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_lm_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -347,26 +357,17 @@ echo "All done. Results are in /local/data/results/"
 
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_lm_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_lm_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_lm_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_lm_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_lm_pcm.log
-  fi
+  for log in \
+      done_lm_toplev.log \
+      done_lm_toplev_execution.log \
+      done_lm_toplev_memory.log \
+      done_lm_maya.log \
+      done_lm_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done_lm.log
 
 rm -f /local/data/results/done_lm_toplev.log \

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -105,6 +105,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Create placeholder logs whenever a tool is disabled so the final summary is
+# predictable regardless of the chosen subset.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_rnn_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_rnn_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_rnn_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_rnn_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_rnn_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -349,26 +359,17 @@ echo "All done. Results are in /local/data/results/"
 ################################################################################
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_rnn_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_rnn_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_rnn_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_rnn_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_rnn_pcm.log
-  fi
+  for log in \
+      done_rnn_toplev.log \
+      done_rnn_toplev_execution.log \
+      done_rnn_toplev_memory.log \
+      done_rnn_maya.log \
+      done_rnn_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done_rnn.log
 
 rm -f /local/data/results/done_rnn_toplev.log \

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -107,6 +107,16 @@ cd /local; mkdir -p data/results
 chown -R "$USER":"$(id -gn)" /local
 chmod -R a+rx /local
 
+# Create placeholder logs for disabled tools so that done.log always lists
+# every profiling stage.
+$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_execution || \
+  echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
+$run_toplev_memory || \
+  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
+$run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
+$run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
+
 ################################################################################
 ### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
 ###    (reserve them for our measurement + workload)
@@ -298,26 +308,17 @@ echo "All done. Results are in /local/data/results/"
 
 {
   echo "Done"
-  if $run_toplev; then
-    echo
-    cat /local/data/results/done_toplev.log
-  fi
-  if $run_toplev_execution; then
-    echo
-    cat /local/data/results/done_toplev_execution.log
-  fi
-  if $run_toplev_memory; then
-    echo
-    cat /local/data/results/done_toplev_memory.log
-  fi
-  if $run_maya; then
-    echo
-    cat /local/data/results/done_maya.log
-  fi
-  if $run_pcm; then
-    echo
-    cat /local/data/results/done_pcm.log
-  fi
+  for log in \
+      done_toplev.log \
+      done_toplev_execution.log \
+      done_toplev_memory.log \
+      done_maya.log \
+      done_pcm.log; do
+    if [[ -f /local/data/results/$log ]]; then
+      echo
+      cat /local/data/results/$log
+    fi
+  done
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev.log \


### PR DESCRIPTION
## Summary
- create skipped-placeholder logs for every tool across run scripts
- keep runtime logs for selected tools and gather all logs into `done.log`

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_3.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869a643abb8832c8da08d1565aff85a