### PR TITLE
Fix tmux relaunch path

### DIFF
--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log


### PR DESCRIPTION
## Summary
- use absolute script paths when launching tmux sessions for ID‑20 run scripts

## Testing
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_6869cdd110f4832cb44f84906e386105