### PR TITLE
Ensure run scripts respect invoking user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,19 @@ tools/maya/            – microarchitectural profiler (C++)
 5. **Style clean‑up** – apply clang‑format or black where appropriate.
 
 6. **Timestamp logging** – after the 10-second countdown, each run script must print `Experiment started at: YYYY-MM-DD - hh:mm` to record the start time.
+7. **User permissions** – before changing ownership of `/local`, run scripts must set:
+   ```bash
+   RUN_USER=${SUDO_USER:-$(id -un)}
+   RUN_GROUP=$(id -gn "$RUN_USER")
+   ```
+   and then invoke `chown -R "$RUN_USER":"$RUN_GROUP" /local`.
+8. **tmux relaunch** – if a run script isn't already inside tmux, it should use:
+   ```bash
+   session_name="$(basename "$0" .sh)"
+   script_path="$(readlink -f "$0")"
+   exec tmux new-session -s "$session_name" "$script_path" "$@"
+   ```
+   Scripts are unpacked in `/local`, so absolute paths ensure consistent relaunch.
 ## Things Codex MUST NOT Do
 
 * Try to run full workloads locally – they assume CloudLab, GPUs, or MATLAB.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log
@@ -95,8 +96,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Prepare placeholder logs for any disabled tools so that log consolidation

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log
@@ -95,8 +96,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Prepare placeholder logs for any disabled tools so that later consolidation

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -102,8 +102,11 @@ secs_to_dhm() {
 
 ### 1. Create results directory (if it doesn't exist already)
 cd /local; mkdir -p data; cd data; mkdir -p results;
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read and execute permissions to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Create placeholder logs for any tools that are disabled so that results

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -102,8 +102,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Create placeholder logs for each disabled tool so that the final aggregation

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -102,8 +102,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Prepare placeholder logs for any disabled tool so that done.log contains an

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -102,8 +102,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Create placeholder logs for tools that aren't selected so that the final

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -102,8 +102,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Create placeholder logs whenever a tool is disabled so the final summary is

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # that it keeps running even if the SSH connection drops.
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."
-  exec tmux new-session -s "$session_name" "$0" "$@"
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
 # Log to /local/logs/run.log
@@ -103,8 +104,11 @@ secs_to_dhm() {
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
 cd /local; mkdir -p data/results
+# Determine permissions target based on original invoking user
+RUN_USER=${SUDO_USER:-$(id -un)}
+RUN_GROUP=$(id -gn "$RUN_USER")
 # Get ownership of /local and grant read+execute to everyone
-chown -R "$USER":"$(id -gn)" /local
+chown -R "$RUN_USER":"$RUN_GROUP" /local
 chmod -R a+rx /local
 
 # Create placeholder logs for disabled tools so that done.log always lists


### PR DESCRIPTION
## Summary
- compute RUN_USER and RUN_GROUP for chown in run scripts
- document new user permission logic in AGENTS guide
- use absolute script paths when relaunching under tmux

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_3.sh`


------
https://chatgpt.com/codex/tasks/task_e_6869dd43bc18832cac1f60a5d9290a8f