### PR TITLE
Reorder profiling steps

### DIFF
--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -120,101 +120,17 @@ $run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
 
 ################################################################################
-### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
-###    (reserve them for our measurement + workload)
-################################################################################
-sudo cset shield --cpu 5,6,15,16 --kthread=on
-
-################################################################################
-### 3. Change into the BCI project directory
+### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
 ################################################################################
-### 4. Maya profiling
-################################################################################
-
-if $run_maya; then
-maya_start=$(date +%s)
-
-# Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  # Start Maya in the background, pinned to CPU 5
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
-
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  # Run the workload pinned to CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-    --datasetPath=/local/data/ptDecoder_ctc \
-    --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1
-
-kill "$MAYA_PID"
-'
-
-# Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
-
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-    --lmDir=/local/data/languageModel/ \
-    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1
-
-kill "$MAYA_PID"
-'
-
-# Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
-sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
-
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1
-
-kill "$MAYA_PID"
-'
-maya_end=$(date +%s)
-maya_runtime=$((maya_end - maya_start))
-echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-  > /local/data/results/done_maya.log
-fi
-
-################################################################################
-### 5. PCM profiling
+### 3. PCM profiling
 ################################################################################
 
 if $run_pcm; then
   pcm_start=$(date +%s)
-  sudo cset shield --reset
   sudo modprobe msr
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -308,6 +224,89 @@ if $run_pcm; then
     echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
     echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_pcm.log
+fi
+
+################################################################################
+### 4. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
+###    (reserve them for our measurement + workload)
+################################################################################
+sudo cset shield --cpu 5,6,15,16 --kthread=on
+
+################################################################################
+### 5. Maya profiling
+################################################################################
+
+if $run_maya; then
+maya_start=$(date +%s)
+
+# Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
+sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  # Start Maya in the background, pinned to CPU 5
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
+
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  # Run the workload pinned to CPU 6
+  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+    --datasetPath=/local/data/ptDecoder_ctc \
+    --modelPath=/local/data/speechBaseline4/ \
+    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1
+
+  kill "$MAYA_PID"
+'
+
+# Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
+sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
+
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+    --lmDir=/local/data/languageModel/ \
+    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1
+
+  kill "$MAYA_PID"
+'
+
+# Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
+sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
+
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+    --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
+    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1
+
+  kill "$MAYA_PID"
+'
+maya_end=$(date +%s)
+maya_runtime=$((maya_end - maya_start))
+echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
+  > /local/data/results/done_maya.log
 fi
 ################################################################################
 ### 6. Toplev execution profiling

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -120,56 +120,16 @@ $run_maya || echo "Maya run skipped" > /local/data/results/done_llm_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_llm_pcm.log
 
 ################################################################################
-### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
-###    (reserve them for our measurement + workload)
-################################################################################
-sudo cset shield --cpu 5,6,15,16 --kthread=on
-
-################################################################################
-### 3. Change into the BCI project directory
+### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Maya profiling
+### 3. PCM profiling
 ################################################################################
-
-if $run_maya; then
-  maya_start=$(date +%s)
-
-  # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
-
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1
-
-  kill "$MAYA_PID"
-  '
-  maya_end=$(date +%s)
-  maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_llm_maya.log
-fi
-
 ################################################################################
-### 5. PCM profiling
-################################################################################
-
 if $run_pcm; then
   pcm_start=$(date +%s)
-  sudo cset shield --reset
   sudo modprobe msr
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -263,6 +223,45 @@ if $run_pcm; then
     echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
     echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_llm_pcm.log
+fi
+
+################################################################################
+### 4. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
+###    (reserve them for our measurement + workload)
+################################################################################
+sudo cset shield --cpu 5,6,15,16 --kthread=on
+
+################################################################################
+### 5. Maya profiling
+################################################################################
+
+if $run_maya; then
+  maya_start=$(date +%s)
+
+  # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
+
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+    --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
+    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1
+
+  kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+  maya_runtime=$((maya_end - maya_start))
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
+    > /local/data/results/done_llm_maya.log
 fi
 
 ################################################################################

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -120,56 +120,16 @@ $run_maya || echo "Maya run skipped" > /local/data/results/done_lm_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_lm_pcm.log
 
 ################################################################################
-### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
-###    (reserve them for our measurement + workload)
-################################################################################
-sudo cset shield --cpu 5,6,15,16 --kthread=on
-
-################################################################################
-### 3. Change into the BCI project directory
+### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Maya profiling
+### 3. PCM profiling
 ################################################################################
-
-if $run_maya; then
-  maya_start=$(date +%s)
-
-  # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
-
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-    --lmDir=/local/data/languageModel/ \
-    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1
-
-  kill "$MAYA_PID"
-  '
-  maya_end=$(date +%s)
-  maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_lm_maya.log
-fi
-
 ################################################################################
-### 5. PCM profiling
-################################################################################
-
 if $run_pcm; then
   pcm_start=$(date +%s)
-  sudo cset shield --reset
   sudo modprobe msr
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -263,6 +223,45 @@ if $run_pcm; then
     echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
     echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_lm_pcm.log
+fi
+
+################################################################################
+### 4. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
+###    (reserve them for our measurement + workload)
+################################################################################
+sudo cset shield --cpu 5,6,15,16 --kthread=on
+
+################################################################################
+### 5. Maya profiling
+################################################################################
+
+if $run_maya; then
+  maya_start=$(date +%s)
+
+  # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
+
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+    --lmDir=/local/data/languageModel/ \
+    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1
+
+  kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+  maya_runtime=$((maya_end - maya_start))
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
+    > /local/data/results/done_lm_maya.log
 fi
 
 ################################################################################

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -120,58 +120,16 @@ $run_maya || echo "Maya run skipped" > /local/data/results/done_rnn_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_rnn_pcm.log
 
 ################################################################################
-### 2. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
-###    (reserve them for our measurement + workload)
-################################################################################
-sudo cset shield --cpu 5,6,15,16 --kthread=on
-
-################################################################################
-### 3. Change into the BCI project directory
+### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 4. Maya profiling
+### 3. PCM profiling
 ################################################################################
-
-if $run_maya; then
-  maya_start=$(date +%s)
-
-  # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-  # Start Maya in the background, pinned to CPU 5
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
-
-  sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
-
-  # Run the workload pinned to CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-    --datasetPath=/local/data/ptDecoder_ctc \
-    --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1
-
-  kill "$MAYA_PID"
-  '
-  maya_end=$(date +%s)
-  maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_rnn_maya.log
-fi
-
 ################################################################################
-### 5. PCM profiling
-################################################################################
-
 if $run_pcm; then
   pcm_start=$(date +%s)
-  sudo cset shield --reset
   sudo modprobe msr
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -265,6 +223,47 @@ if $run_pcm; then
     echo "PCM-power runtime:   $(secs_to_dhm "$pcm_power_runtime")"
     echo "PCM-pcie runtime:    $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_rnn_pcm.log
+fi
+
+################################################################################
+### 4. Shield Core 8 (CPU 5 and CPU 15) and Core 9 (CPU 6 and CPU 16)
+###    (reserve them for our measurement + workload)
+################################################################################
+sudo cset shield --cpu 5,6,15,16 --kthread=on
+
+################################################################################
+### 5. Maya profiling
+################################################################################
+
+if $run_maya; then
+  maya_start=$(date +%s)
+
+  # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  # Start Maya in the background, pinned to CPU 5
+  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
+
+  sleep 1
+  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
+
+  # Run the workload pinned to CPU 6
+  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+    --datasetPath=/local/data/ptDecoder_ctc \
+    --modelPath=/local/data/speechBaseline4/ \
+    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1
+
+  kill "$MAYA_PID"
+  '
+  maya_end=$(date +%s)
+  maya_runtime=$((maya_end - maya_start))
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
+    > /local/data/results/done_rnn_maya.log
 fi
 
 ################################################################################


### PR DESCRIPTION
## Summary
- reorder profiling sections in run scripts
- move CPU shielding after PCM runs
- run PCM before Maya and toplev

## Testing
- `bash -n scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869e832df20832c88d48dfc8340f21a