### PR TITLE
Improve run script logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ tools/maya/            – microarchitectural profiler (C++)
 4. **Light testing** – unit‑test pure Python utilities (e.g. id\_3/code/utils.py).
 5. **Style clean‑up** – apply clang‑format or black where appropriate.
 
-6. **Timestamp logging** – after the 10-second countdown, each run script must print `Experiment started at: YYYY-MM-DD - hh:mm` to record the start time.
+6. **Timestamp logging** – after the 10-second countdown, each run script must print `Experiment started at: YYYY-MM-DD - hh:mm` and when complete print `Experiment finished at: YYYY-MM-DD - hh:mm`.  Major profiling stages should also announce their start and end times.
 7. **User permissions** – before changing ownership of `/local`, run scripts must set:
    ```bash
    RUN_USER=${SUDO_USER:-$(id -un)}

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -123,6 +128,7 @@ cd ~
 ################################################################################
 
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo sh -c '
@@ -154,6 +160,7 @@ if $run_pcm; then
     >>/local/data/results/id_1_pcm_pcie.log 2>&1
   '
   pcm_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
@@ -170,6 +177,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     # Start Maya on core 5 in background, log raw output
@@ -188,6 +196,7 @@ if $run_maya; then
     kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
@@ -198,6 +207,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
@@ -207,6 +217,7 @@ if $run_toplev_execution; then
           >> /local/data/results/id_1_toplev_execution.log 2>&1
   '
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
@@ -217,6 +228,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo cset shield --exec -- sh -c "
     taskset -c 5 /local/tools/pmu-tools/toplev \
@@ -226,6 +238,7 @@ if $run_toplev_memory; then
           >> /local/data/results/id_1_toplev_memory.log 2>&1
   "
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_toplev_memory.log
@@ -236,6 +249,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
@@ -245,6 +259,7 @@ if $run_toplev; then
           >> /local/data/results/id_1_toplev.log 2>&1
   '
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
@@ -270,6 +285,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -123,6 +128,7 @@ cd /local/tools/bci_project
 ################################################################################
 ################################################################################
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo sh -c '
@@ -154,6 +160,7 @@ if $run_pcm; then
     >>/local/data/results/id_13_pcm_pcie.log 2>&1
   '
   pcm_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   {
     echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
@@ -171,6 +178,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -190,6 +198,7 @@ if $run_maya; then
     kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
@@ -200,6 +209,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -214,6 +224,7 @@ if $run_toplev_execution; then
           -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
   ' &> /local/data/results/id_13_toplev_execution.log
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
@@ -224,6 +235,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -238,6 +250,7 @@ if $run_toplev_memory; then
           -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
   ' &> /local/data/results/id_13_toplev_memory.log
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_toplev_memory.log
@@ -248,6 +261,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -262,6 +276,7 @@ if $run_toplev; then
           -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
   ' &> /local/data/results/id_13_toplev.log
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
@@ -281,6 +296,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -137,6 +142,7 @@ export PYTHONPATH=$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:$PYTHONPATH
 ################################################################################
 
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo -E bash -lc '
@@ -221,6 +227,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
@@ -244,6 +251,7 @@ cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
   # Run the RNN script
@@ -295,6 +303,7 @@ if $run_maya; then
     kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
@@ -304,6 +313,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   # RNN script
   sudo -E cset shield --exec -- sh -c '
@@ -335,6 +345,7 @@ if $run_toplev_execution; then
           >> /local/data/results/id_20_llm_toplev_execution.log 2>&1
   '
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
@@ -344,6 +355,7 @@ fi
 ### 7. Toplev memory profiling
 ################################################################################
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   # RNN script
   sudo -E cset shield --exec -- sh -c "
@@ -375,6 +387,7 @@ if $run_toplev_memory; then
           >> /local/data/results/id_20_llm_toplev_memory.log 2>&1
   "
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_toplev_memory.log
@@ -384,6 +397,7 @@ fi
 ### 8. Toplev profiling
 ################################################################################
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
 
   # Run the RNN script
@@ -416,6 +430,7 @@ if $run_toplev; then
           >> /local/data/results/id_20_llm_toplev.log 2>&1
   '
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
@@ -449,6 +464,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -130,6 +135,7 @@ cd /local/tools/bci_project
 ################################################################################
 
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo -E bash -lc '
@@ -214,6 +220,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
@@ -237,6 +244,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+echo "Maya profiling started at: $(timestamp)"
 maya_start=$(date +%s)
 
 # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -304,6 +312,7 @@ sudo -E cset shield --exec -- bash -lc '
   kill "$MAYA_PID"
 '
 maya_end=$(date +%s)
+echo "Maya profiling finished at: $(timestamp)"
 maya_runtime=$((maya_end - maya_start))
 echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
   > /local/data/results/done_maya.log
@@ -313,6 +322,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -356,6 +366,7 @@ if $run_toplev_execution; then
           --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
   ' &> /local/data/results/id_20_3gram_llm_toplev_execution.log
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
@@ -366,6 +377,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc "
     source /local/tools/bci_env/bin/activate
@@ -409,6 +421,7 @@ if $run_toplev_memory; then
           --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
   " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_toplev_memory.log
@@ -419,6 +432,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -462,6 +476,7 @@ if $run_toplev; then
           --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
   ' &> /local/data/results/id_20_3gram_llm_toplev.log
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
@@ -492,6 +507,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -129,6 +134,7 @@ cd /local/tools/bci_project
 ################################################################################
 ################################################################################
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo -E bash -lc '
@@ -213,6 +219,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_llm_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
@@ -236,6 +243,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
   # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -259,6 +267,7 @@ if $run_maya; then
   kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_llm_maya.log
@@ -269,6 +278,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -284,6 +294,7 @@ if $run_toplev_execution; then
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
   ' &> /local/data/results/id_20_3gram_llm_toplev_execution.log
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_llm_toplev_execution.log
@@ -294,6 +305,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc "
   source /local/tools/bci_env/bin/activate
@@ -309,6 +321,7 @@ if $run_toplev_memory; then
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
   " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_llm_toplev_memory.log
@@ -319,6 +332,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -334,6 +348,7 @@ if $run_toplev; then
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
   ' &> /local/data/results/id_20_3gram_llm_toplev.log
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_llm_toplev.log
@@ -353,6 +368,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -129,6 +134,7 @@ cd /local/tools/bci_project
 ################################################################################
 ################################################################################
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo -E bash -lc '
@@ -213,6 +219,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_lm_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
@@ -236,6 +243,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
   # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -259,6 +267,7 @@ if $run_maya; then
   kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_lm_maya.log
@@ -269,6 +278,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -284,6 +294,7 @@ if $run_toplev_execution; then
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
   ' &> /local/data/results/id_20_3gram_lm_toplev_execution.log
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_lm_toplev_execution.log
@@ -294,6 +305,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc "
   source /local/tools/bci_env/bin/activate
@@ -309,6 +321,7 @@ if $run_toplev_memory; then
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
   " &> /local/data/results/id_20_3gram_lm_toplev_memory.log
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_lm_toplev_memory.log
@@ -319,6 +332,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -334,6 +348,7 @@ if $run_toplev; then
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
   ' &> /local/data/results/id_20_3gram_lm_toplev.log
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_lm_toplev.log
@@ -353,6 +368,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -129,6 +134,7 @@ cd /local/tools/bci_project
 ################################################################################
 ################################################################################
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   sudo -E bash -lc '
@@ -213,6 +219,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_rnn_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
@@ -236,6 +243,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
   # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -261,6 +269,7 @@ if $run_maya; then
   kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_rnn_maya.log
@@ -271,6 +280,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -286,6 +296,7 @@ if $run_toplev_execution; then
         --modelPath=/local/data/speechBaseline4/
   ' &> /local/data/results/id_20_3gram_rnn_toplev_execution.log
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_rnn_toplev_execution.log
@@ -296,6 +307,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc "
   source /local/tools/bci_env/bin/activate
@@ -311,6 +323,7 @@ if $run_toplev_memory; then
         --modelPath=/local/data/speechBaseline4/
   " &> /local/data/results/id_20_3gram_rnn_toplev_memory.log
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_rnn_toplev_memory.log
@@ -321,6 +334,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -337,6 +351,7 @@ toplev_end=$(date +%s)
         --modelPath=/local/data/speechBaseline4/
   ' &> /local/data/results/id_20_3gram_rnn_toplev.log
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_rnn_toplev.log
@@ -356,6 +371,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -74,6 +74,11 @@ done
 
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
+# Helper for consistent timestamps
+timestamp() {
+  TZ=America/Toronto date '+%Y-%m-%d - %H:%M'
+}
+
 # Initialize timing variables
 toplev_start=0
 toplev_end=0
@@ -133,6 +138,7 @@ source /local/tools/compression_env/bin/activate
 ################################################################################
 ################################################################################
 if $run_pcm; then
+  echo "PCM profiling started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo modprobe msr
   pcm_gen_start=$(date +%s)
@@ -180,6 +186,7 @@ if $run_pcm; then
   '
   pcm_pcie_end=$(date +%s)
   pcm_end=$(date +%s)
+  echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_gen_runtime=$((pcm_gen_end - pcm_gen_start))
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
@@ -205,6 +212,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/compression_env/bin/activate
@@ -223,6 +231,7 @@ if $run_maya; then
     kill "$MAYA_PID"
   '
   maya_end=$(date +%s)
+  echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
@@ -233,6 +242,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/compression_env/bin/activate
@@ -243,6 +253,7 @@ if $run_toplev_execution; then
         taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac
   ' &>  /local/data/results/id_3_toplev_execution.log
   toplev_execution_end=$(date +%s)
+  echo "Toplev execution profiling finished at: $(timestamp)"
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
@@ -253,6 +264,7 @@ fi
 ################################################################################
 
 if $run_toplev_memory; then
+  echo "Toplev memory profiling started at: $(timestamp)"
   toplev_memory_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc "
     source /local/tools/compression_env/bin/activate
@@ -263,6 +275,7 @@ if $run_toplev_memory; then
         taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac
   " &>  /local/data/results/id_3_toplev_memory.log
   toplev_memory_end=$(date +%s)
+  echo "Toplev memory profiling finished at: $(timestamp)"
   toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
   echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
     > /local/data/results/done_toplev_memory.log
@@ -273,6 +286,7 @@ fi
 ################################################################################
 
 if $run_toplev; then
+  echo "Toplev profiling started at: $(timestamp)"
   toplev_start=$(date +%s)
 
   sudo -E cset shield --exec -- bash -lc '
@@ -284,6 +298,7 @@ if $run_toplev; then
         taskset -c 6 python3 scripts/benchmark-lossless.py aind-np1 0.1s flac
   ' &>  /local/data/results/id_3_toplev.log
   toplev_end=$(date +%s)
+  echo "Toplev profiling finished at: $(timestamp)"
   toplev_runtime=$((toplev_end - toplev_start))
   echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
     > /local/data/results/done_toplev.log
@@ -304,6 +319,8 @@ fi
 ### 10. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
+
+echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
 ### 11. Write completion file with runtimes


### PR DESCRIPTION
## Summary
- add timestamp helper and logs for profiling stages in run scripts
- show when experiments finish
- document timestamp logging updates in AGENTS guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a2990f6d0832c8012aa02b8088277