### PR TITLE
Add final success messages to workload scripts

### DIFF
--- a/id_1/main.c
+++ b/id_1/main.c
@@ -74,6 +74,8 @@ int main(){
         log_phase("POSTPROC", "END");
         toc(tvBegin, tvDiff, tvEnd);
     }
+    printf("Workload finished successfully\n");
+    fflush(stdout);
     return 0;
 }
 

--- a/id_13/motor_movement.m
+++ b/id_13/motor_movement.m
@@ -299,7 +299,7 @@ function motor_movement(dataPath, libPath)
 
     % save the figure and signal completion
     saveas(gcf, '/local/data/results/osci_plot.png');
-    fprintf('Done!\n');
+    fprintf('Workload finished successfully\n');
 
     function log_phase(name, stage)
         nowTime = datetime('now','TimeZone','UTC');

--- a/id_20/code/neural_seq_decoder/scripts/llm_model_run.py
+++ b/id_20/code/neural_seq_decoder/scripts/llm_model_run.py
@@ -291,3 +291,5 @@ for i in range(len(nbest_outputs)):
     print("\t LM: ", lm)
     print("\t LLM: ", llm)
 
+print("Workload finished successfully", flush=True)
+

--- a/id_20/code/neural_seq_decoder/scripts/rnn_run.py
+++ b/id_20/code/neural_seq_decoder/scripts/rnn_run.py
@@ -101,3 +101,5 @@ log_phase('SAVE','START')
 with open("rnn_results.pkl", "wb") as f:
     pickle.dump(rnn_outputs, f)
 log_phase('SAVE','END')
+
+print("Workload finished successfully", flush=True)

--- a/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py
+++ b/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py
@@ -397,6 +397,8 @@ log_phase('SAVE','END')
 
 print("Error rates: ", cer_pre_opt(nbest_outputs, rnn_outputs))
 
+print("Workload finished successfully", flush=True)
+
 
 
 

--- a/id_3/code/scripts/benchmark-lossless.py
+++ b/id_3/code/scripts/benchmark-lossless.py
@@ -439,3 +439,4 @@ if __name__ == "__main__":
 
     # final
     shutil.rmtree(tmp_folder)
+    print("Workload finished successfully", flush=True)


### PR DESCRIPTION
## Summary
- ensure each workload signals completion
- print completion message in MATLAB movement script
- add success prints to Python workloads
- emit success notice from C workload

## Testing
- `python -m py_compile id_3/code/scripts/benchmark-lossless.py`
- `python -m py_compile id_20/code/neural_seq_decoder/scripts/rnn_run.py`
- `python -m py_compile id_20/code/neural_seq_decoder/scripts/wfst_model_run.py`
- `python -m py_compile id_20/code/neural_seq_decoder/scripts/llm_model_run.py`
- `gcc -std=c99 -fopenmp id_1/main.c id_1/associative_memory.c id_1/aux_functions.c -o id_1/main -lm` *(fails: data.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af452a074832c8390b0a0060b9659