### PR TITLE
Add toplev-basic profiling option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,5 +94,6 @@ An example `setup.sh` lives at repo root and installs:
 
 After each change, update this document to reflect the current repository
 structure or processes.
-The run scripts now include an optional `toplev-ip` profiling mode that can be
-enabled via `--toplev-ip`, `--short`, or `--long`.
+The run scripts now include optional `toplev-basic` and `toplev-ip` profiling modes that can be
+enabled via `--toplev-basic` or `--toplev-ip`, and are automatically selected with
+`--short` or `--long`.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -16,6 +16,7 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
+run_toplev_basic=false
 run_toplev=false
 run_toplev_execution=false
 run_toplev_memory=false
@@ -24,6 +25,7 @@ run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --toplev-basic)      run_toplev_basic=true ;;
     --toplev)            run_toplev=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
     --toplev-memory)     run_toplev_memory=true ;;
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
+      run_toplev_basic=true
       run_toplev=false
       run_toplev_execution=true
       run_toplev_memory=true
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       run_pcm=true
       ;;
     --long)
+      run_toplev_basic=true
       run_toplev=true
       run_toplev_execution=true
       run_toplev_memory=true
@@ -50,8 +54,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
+if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
     && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
   run_toplev=true
   run_toplev_execution=true
   run_toplev_memory=true
@@ -65,6 +70,7 @@ workload_desc="ID-1 (Seizure Detection – Laelaps)"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
+$run_toplev_basic && tools_list+=("toplev-basic")
 $run_toplev && tools_list+=("toplev")
 $run_toplev_execution && tools_list+=("toplev-execution")
 $run_toplev_memory && tools_list+=("toplev-memory")
@@ -86,6 +92,8 @@ timestamp() {
 }
 
 # Initialize timing variables
+toplev_basic_start=0
+toplev_basic_end=0
 toplev_start=0
 toplev_end=0
 toplev_execution_start=0
@@ -118,6 +126,7 @@ chmod -R a+rx /local
 
 # Prepare placeholder logs for any disabled tools so that log consolidation
 # works regardless of the selected combination.
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
 $run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
@@ -213,7 +222,28 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev execution profiling
+### 6. Toplev basic profiling
+################################################################################
+
+if $run_toplev_basic; then
+  echo "Toplev basic profiling started at: $(timestamp)"
+  toplev_basic_start=$(date +%s)
+  sudo cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -o /local/data/results/id_1_toplev_basic.csv -- \
+        taskset -c 6 /local/bci_code/id_1/main \
+          >> /local/data/results/id_1_toplev_basic.log 2>&1
+  '
+  toplev_basic_end=$(date +%s)
+  echo "Toplev basic profiling finished at: $(timestamp)"
+  toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
+  echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
+    > /local/data/results/done_toplev_basic.log
+fi
+
+################################################################################
+### 7. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -234,7 +264,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 7. Toplev memory profiling
+### 8. Toplev memory profiling
 ################################################################################
 
 if $run_toplev_memory; then
@@ -255,7 +285,7 @@ if $run_toplev_memory; then
 fi
 
 ################################################################################
-### 8. Toplev IP profiling
+### 9. Toplev IP profiling
 ################################################################################
 
 if $run_toplev_ip; then
@@ -276,7 +306,7 @@ if $run_toplev_ip; then
 fi
 
 ################################################################################
-### 9. Toplev profiling
+### 10. Toplev profiling
 ################################################################################
 
 if $run_toplev; then
@@ -297,7 +327,7 @@ if $run_toplev; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -313,18 +343,19 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"
   for log in \
+      done_toplev_basic.log \
       done_toplev.log \
       done_toplev_execution.log \
       done_toplev_memory.log \
@@ -338,7 +369,8 @@ echo "Experiment finished at: $(timestamp)"
   done
 } > /local/data/results/done.log
 
-rm -f /local/data/results/done_toplev.log \
+rm -f /local/data/results/done_toplev_basic.log \
+      /local/data/results/done_toplev.log \
       /local/data/results/done_toplev_execution.log \
       /local/data/results/done_toplev_memory.log \
       /local/data/results/done_toplev_ip.log \

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -16,6 +16,7 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
+run_toplev_basic=false
 run_toplev=false
 run_toplev_execution=false
 run_toplev_memory=false
@@ -24,6 +25,7 @@ run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --toplev-basic)      run_toplev_basic=true ;;
     --toplev)            run_toplev=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
     --toplev-memory)     run_toplev_memory=true ;;
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
+      run_toplev_basic=true
       run_toplev=false
       run_toplev_execution=true
       run_toplev_memory=true
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       run_pcm=true
       ;;
     --long)
+      run_toplev_basic=true
       run_toplev=true
       run_toplev_execution=true
       run_toplev_memory=true
@@ -50,8 +54,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
+if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
     && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
   run_toplev=true
   run_toplev_execution=true
   run_toplev_memory=true
@@ -65,6 +70,7 @@ workload_desc="ID-13 (Movement Intent)"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
+$run_toplev_basic && tools_list+=("toplev-basic")
 $run_toplev && tools_list+=("toplev")
 $run_toplev_execution && tools_list+=("toplev-execution")
 $run_toplev_memory && tools_list+=("toplev-memory")
@@ -86,6 +92,8 @@ timestamp() {
 }
 
 # Initialize timing variables
+toplev_basic_start=0
+toplev_basic_end=0
 toplev_start=0
 toplev_end=0
 toplev_execution_start=0
@@ -118,6 +126,7 @@ chmod -R a+rx /local
 
 # Prepare placeholder logs for any disabled tools so that later consolidation
 # yields a consistent done.log.
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
 $run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
@@ -215,7 +224,33 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev execution profiling
+### 6. Toplev basic profiling
+################################################################################
+
+if $run_toplev_basic; then
+  echo "Toplev basic profiling started at: $(timestamp)"
+  toplev_basic_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
+    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
+    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
+
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -o /local/data/results/id_13_toplev_basic.csv -- \
+        taskset -c 6 /local/tools/matlab/bin/matlab \
+          -nodisplay -nosplash \
+          -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
+  ' &> /local/data/results/id_13_toplev_basic.log
+  toplev_basic_end=$(date +%s)
+  echo "Toplev basic profiling finished at: $(timestamp)"
+  toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
+  echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
+    > /local/data/results/done_toplev_basic.log
+fi
+
+################################################################################
+### 7. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -241,7 +276,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 7. Toplev memory profiling
+### 8. Toplev memory profiling
 ################################################################################
 
 if $run_toplev_memory; then
@@ -267,7 +302,7 @@ if $run_toplev_memory; then
 fi
 
 ################################################################################
-### 8. Toplev IP profiling
+### 9. Toplev IP profiling
 ################################################################################
 
 if $run_toplev_ip; then
@@ -293,7 +328,7 @@ if $run_toplev_ip; then
 fi
 
 ################################################################################
-### 9. Toplev profiling
+### 10. Toplev profiling
 ################################################################################
 
 if $run_toplev; then
@@ -319,7 +354,7 @@ if $run_toplev; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -329,19 +364,20 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
   echo "Done"
   for log in \
+      done_toplev_basic.log \
       done_toplev.log \
       done_toplev_execution.log \
       done_toplev_memory.log \
@@ -355,7 +391,8 @@ echo "Experiment finished at: $(timestamp)"
   done
 } > /local/data/results/done.log
 
-rm -f /local/data/results/done_toplev.log \
+rm -f /local/data/results/done_toplev_basic.log \
+      /local/data/results/done_toplev.log \
       /local/data/results/done_toplev_execution.log \
       /local/data/results/done_toplev_memory.log \
       /local/data/results/done_toplev_ip.log \

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -16,6 +16,7 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
+run_toplev_basic=false
 run_toplev=false
 run_toplev_execution=false
 run_toplev_memory=false
@@ -24,6 +25,7 @@ run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --toplev-basic)      run_toplev_basic=true ;;
     --toplev)            run_toplev=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
     --toplev-memory)     run_toplev_memory=true ;;
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
+      run_toplev_basic=true
       run_toplev=false
       run_toplev_execution=true
       run_toplev_memory=true
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       run_pcm=true
       ;;
     --long)
+      run_toplev_basic=true
       run_toplev=true
       run_toplev_execution=true
       run_toplev_memory=true
@@ -50,8 +54,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
+if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
     && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
   run_toplev=true
   run_toplev_execution=true
   run_toplev_memory=true
@@ -65,6 +70,7 @@ workload_desc="ID-20 (Speech Decoding)"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
+$run_toplev_basic && tools_list+=("toplev-basic")
 $run_toplev && tools_list+=("toplev")
 $run_toplev_execution && tools_list+=("toplev-execution")
 $run_toplev_memory && tools_list+=("toplev-memory")
@@ -86,6 +92,8 @@ timestamp() {
 }
 
 # Initialize timing variables
+toplev_basic_start=0
+toplev_basic_end=0
 toplev_start=0
 toplev_end=0
 toplev_execution_start=0
@@ -124,6 +132,7 @@ chmod -R a+rx /local
 
 # Create placeholder logs for any tools that are disabled so that results
 # aggregation behaves consistently across run configurations.
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
 $run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
@@ -318,8 +327,54 @@ if $run_maya; then
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
+
 ################################################################################
-### 6. Toplev execution profiling
+### 6. Toplev basic profiling
+################################################################################
+
+if $run_toplev_basic; then
+  echo "Toplev basic profiling started at: $(timestamp)"
+  toplev_basic_start=$(date +%s)
+
+  # RNN script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -o /local/data/results/id_20_rnn_toplev_basic.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/ \
+          >> /local/data/results/id_20_rnn_toplev_basic.log 2>&1
+  '
+
+  # LM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -o /local/data/results/id_20_lm_toplev_basic.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+          --lmDir=/local/data/languageModel/ \
+          >> /local/data/results/id_20_lm_toplev_basic.log 2>&1
+  '
+
+  # LLM script
+  sudo -E cset shield --exec -- sh -c '
+    taskset -c 5 /local/tools/pmu-tools/toplev \
+      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -o /local/data/results/id_20_llm_toplev_basic.csv -- \
+        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          >> /local/data/results/id_20_llm_toplev_basic.log 2>&1
+  '
+
+  toplev_basic_end=$(date +%s)
+  echo "Toplev basic profiling finished at: $(timestamp)"
+  toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
+  echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
+    > /local/data/results/done_toplev_basic.log
+fi
+
+################################################################################
+### 7. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -362,7 +417,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 7. Toplev memory profiling
+### 8. Toplev memory profiling
 ################################################################################
 if $run_toplev_memory; then
   echo "Toplev memory profiling started at: $(timestamp)"
@@ -404,7 +459,7 @@ if $run_toplev_memory; then
 fi
 
 ################################################################################
-### 8. Toplev IP profiling
+### 9. Toplev IP profiling
 ################################################################################
 
 if $run_toplev_ip; then
@@ -448,7 +503,7 @@ if $run_toplev_ip; then
 fi
 
 ################################################################################
-### 9. Toplev profiling
+### 10. Toplev profiling
 ################################################################################
 if $run_toplev; then
   echo "Toplev profiling started at: $(timestamp)"
@@ -490,7 +545,7 @@ if $run_toplev; then
     > /local/data/results/done_toplev.log
 fi
 ################################################################################
-### 10. Convert Maya raw output to CSV
+### 11. Convert Maya raw output to CSV
 ################################################################################
 
 if $run_maya; then
@@ -515,19 +570,20 @@ fi
 
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
   echo "Done"
   for log in \
+      done_toplev_basic.log \
       done_toplev.log \
       done_toplev_execution.log \
       done_toplev_memory.log \
@@ -541,7 +597,8 @@ echo "Experiment finished at: $(timestamp)"
   done
 } > /local/data/results/done.log
 
-rm -f /local/data/results/done_toplev.log \
+rm -f /local/data/results/done_toplev_basic.log \
+      /local/data/results/done_toplev.log \
       /local/data/results/done_toplev_execution.log \
       /local/data/results/done_toplev_memory.log \
       /local/data/results/done_toplev_ip.log \

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -16,6 +16,7 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
+run_toplev_basic=false
 run_toplev=false
 run_toplev_execution=false
 run_toplev_memory=false
@@ -24,6 +25,7 @@ run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --toplev-basic)      run_toplev_basic=true ;;
     --toplev)            run_toplev=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
     --toplev-memory)     run_toplev_memory=true ;;
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
+      run_toplev_basic=true
       run_toplev=false
       run_toplev_execution=true
       run_toplev_memory=true
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       run_pcm=true
       ;;
     --long)
+      run_toplev_basic=true
       run_toplev=true
       run_toplev_execution=true
       run_toplev_memory=true
@@ -50,8 +54,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
+if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
     && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
   run_toplev=true
   run_toplev_execution=true
   run_toplev_memory=true
@@ -65,6 +70,7 @@ workload_desc="ID-20 3gram"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
+$run_toplev_basic && tools_list+=("toplev-basic")
 $run_toplev && tools_list+=("toplev")
 $run_toplev_execution && tools_list+=("toplev-execution")
 $run_toplev_memory && tools_list+=("toplev-memory")
@@ -86,6 +92,8 @@ timestamp() {
 }
 
 # Initialize timing variables
+toplev_basic_start=0
+toplev_basic_end=0
 toplev_start=0
 toplev_end=0
 toplev_execution_start=0
@@ -124,6 +132,7 @@ chmod -R a+rx /local
 
 # Create placeholder logs for each disabled tool so that the final aggregation
 # step can handle every combination of selected programs.
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
 $run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
@@ -327,8 +336,69 @@ maya_runtime=$((maya_end - maya_start))
 echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
   > /local/data/results/done_maya.log
 fi
+
 ################################################################################
-### 6. Toplev execution profiling
+### 6. Toplev basic profiling
+################################################################################
+
+if $run_toplev_basic; then
+  echo "Toplev basic profiling started at: $(timestamp)"
+  toplev_basic_start=$(date +%s)
+
+  # RNN script
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -o /local/data/results/id_20_3gram_rnn_toplev_basic.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/
+  ' &> /local/data/results/id_20_3gram_rnn_toplev_basic.log
+
+  # LM script
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -o /local/data/results/id_20_3gram_lm_toplev_basic.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+        --lmDir=/local/data/languageModel/ \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
+  ' &> /local/data/results/id_20_3gram_lm_toplev_basic.log
+
+  # LLM script
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  ' &> /local/data/results/id_20_3gram_llm_toplev_basic.log
+
+  toplev_basic_end=$(date +%s)
+  echo "Toplev basic profiling finished at: $(timestamp)"
+  toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
+  echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
+    > /local/data/results/done_toplev_basic.log
+fi
+
+################################################################################
+### 7. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -383,7 +453,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 7. Toplev memory profiling
+### 8. Toplev memory profiling
 ################################################################################
 
 if $run_toplev_memory; then
@@ -438,7 +508,7 @@ if $run_toplev_memory; then
 fi
 
 ################################################################################
-### 8. Toplev IP profiling
+### 9. Toplev IP profiling
 ################################################################################
 
 if $run_toplev_ip; then
@@ -493,7 +563,7 @@ if $run_toplev_ip; then
 fi
 
 ################################################################################
-### 9. Toplev profiling
+### 10. Toplev profiling
 ################################################################################
 
 if $run_toplev; then
@@ -548,7 +618,7 @@ if $run_toplev; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -569,19 +639,20 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
   echo "Done"
   for log in \
+      done_toplev_basic.log \
       done_toplev.log \
       done_toplev_execution.log \
       done_toplev_memory.log \
@@ -595,7 +666,8 @@ echo "Experiment finished at: $(timestamp)"
   done
 } > /local/data/results/done.log
 
-rm -f /local/data/results/done_toplev.log \
+rm -f /local/data/results/done_toplev_basic.log \
+      /local/data/results/done_toplev.log \
       /local/data/results/done_toplev_execution.log \
       /local/data/results/done_toplev_memory.log \
       /local/data/results/done_toplev_ip.log \

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -16,6 +16,7 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
+run_toplev_basic=false
 run_toplev=false
 run_toplev_execution=false
 run_toplev_memory=false
@@ -24,6 +25,7 @@ run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --toplev-basic)      run_toplev_basic=true ;;
     --toplev)            run_toplev=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
     --toplev-memory)     run_toplev_memory=true ;;
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
+      run_toplev_basic=true
       run_toplev=false
       run_toplev_execution=true
       run_toplev_memory=true
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       run_pcm=true
       ;;
     --long)
+      run_toplev_basic=true
       run_toplev=true
       run_toplev_execution=true
       run_toplev_memory=true
@@ -50,8 +54,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
+if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
     && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
   run_toplev=true
   run_toplev_execution=true
   run_toplev_memory=true
@@ -65,6 +70,7 @@ workload_desc="ID-20 3gram LLM"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
+$run_toplev_basic && tools_list+=("toplev-basic")
 $run_toplev && tools_list+=("toplev")
 $run_toplev_execution && tools_list+=("toplev-execution")
 $run_toplev_memory && tools_list+=("toplev-memory")
@@ -86,6 +92,8 @@ timestamp() {
 }
 
 # Initialize timing variables
+toplev_basic_start=0
+toplev_basic_end=0
 toplev_start=0
 toplev_end=0
 toplev_execution_start=0
@@ -124,6 +132,7 @@ chmod -R a+rx /local
 
 # Prepare placeholder logs for any disabled tool so that done.log contains an
 # entry for every possible stage.
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_llm_toplev_basic.log
 $run_toplev || echo "Toplev run skipped" > /local/data/results/done_llm_toplev.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_llm_toplev_execution.log
@@ -279,12 +288,39 @@ if $run_maya; then
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_llm_maya.log
+echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
+  > /local/data/results/done_llm_maya.log
 fi
 
 ################################################################################
-### 6. Toplev execution profiling
+### 6. Toplev basic profiling
+################################################################################
+
+if $run_toplev_basic; then
+  echo "Toplev basic profiling started at: $(timestamp)"
+  toplev_basic_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+  ' &> /local/data/results/id_20_3gram_llm_toplev_basic.log
+  toplev_basic_end=$(date +%s)
+  echo "Toplev basic profiling finished at: $(timestamp)"
+  toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
+  echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
+    > /local/data/results/done_llm_toplev_basic.log
+fi
+
+################################################################################
+### 7. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -311,7 +347,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 7. Toplev memory profiling
+### 8. Toplev memory profiling
 ################################################################################
 
 if $run_toplev_memory; then
@@ -338,7 +374,7 @@ if $run_toplev_memory; then
 fi
 
 ################################################################################
-### 8. Toplev IP profiling
+### 9. Toplev IP profiling
 ################################################################################
 
 if $run_toplev_ip; then
@@ -365,7 +401,7 @@ if $run_toplev_ip; then
 fi
 
 ################################################################################
-### 9. Toplev profiling
+### 10. Toplev profiling
 ################################################################################
 
 if $run_toplev; then
@@ -391,7 +427,7 @@ if $run_toplev; then
     > /local/data/results/done_llm_toplev.log
 fi
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -402,19 +438,20 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
   echo "Done"
   for log in \
+      done_llm_toplev_basic.log \
       done_llm_toplev.log \
       done_llm_toplev_execution.log \
       done_llm_toplev_memory.log \
@@ -428,7 +465,8 @@ echo "Experiment finished at: $(timestamp)"
   done
 } > /local/data/results/done_llm.log
 
-rm -f /local/data/results/done_llm_toplev.log \
+rm -f /local/data/results/done_llm_toplev_basic.log \
+      /local/data/results/done_llm_toplev.log \
       /local/data/results/done_llm_toplev_execution.log \
       /local/data/results/done_llm_toplev_memory.log \
       /local/data/results/done_llm_toplev_ip.log \

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -16,6 +16,7 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
+run_toplev_basic=false
 run_toplev=false
 run_toplev_execution=false
 run_toplev_memory=false
@@ -24,6 +25,7 @@ run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --toplev-basic)      run_toplev_basic=true ;;
     --toplev)            run_toplev=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
     --toplev-memory)     run_toplev_memory=true ;;
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
+      run_toplev_basic=true
       run_toplev=false
       run_toplev_execution=true
       run_toplev_memory=true
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       run_pcm=true
       ;;
     --long)
+      run_toplev_basic=true
       run_toplev=true
       run_toplev_execution=true
       run_toplev_memory=true
@@ -50,8 +54,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
+if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_memory \
     && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
   run_toplev=true
   run_toplev_execution=true
   run_toplev_memory=true
@@ -65,6 +70,7 @@ workload_desc="ID-20 3gram LM"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
+$run_toplev_basic && tools_list+=("toplev-basic")
 $run_toplev && tools_list+=("toplev")
 $run_toplev_execution && tools_list+=("toplev-execution")
 $run_toplev_memory && tools_list+=("toplev-memory")
@@ -86,6 +92,8 @@ timestamp() {
 }
 
 # Initialize timing variables
+toplev_basic_start=0
+toplev_basic_end=0
 toplev_start=0
 toplev_end=0
 toplev_execution_start=0
@@ -124,6 +132,7 @@ chmod -R a+rx /local
 
 # Create placeholder logs for tools that aren't selected so that the final
 # summary always lists every stage.
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_lm_toplev_basic.log
 $run_toplev || echo "Toplev run skipped" > /local/data/results/done_lm_toplev.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_lm_toplev_execution.log


### PR DESCRIPTION
## Summary
- add `toplev-basic` run option to scripts
- insert new profiling step before existing toplev runs
- include toplev-basic in `--short` and `--long`
- update AGENTS

## Testing
- `bash -n scripts/run_3.sh`
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_686b192c7ed0832cb2627f69f5fe9b7a