### PR TITLE
Consolidate toplev profiling scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ An example `setup.sh` lives at repo root and installs:
 ## Maintenance rule
 
 After each change, update this document to reflect the current repository
-structure or processes.
-The run scripts now include optional `toplev-basic`, `toplev-cache`, and `toplev-ip` profiling modes that can be
-enabled via `--toplev-basic`, `--toplev-cache`, or `--toplev-ip`, and are automatically selected with
-`--short` or `--long`.
+structure or processes. The run scripts now support three Toplev profiling
+modes: `toplev-basic`, `toplev-execution` and `toplev-full`. They can be
+enabled via `--toplev-basic`, `--toplev-execution` or `--toplev-full` and are
+automatically selected when invoking `--short` or `--long`.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -17,55 +17,39 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 # Parse tool selection arguments inside tmux
 run_toplev_basic=false
-run_toplev=false
+run_toplev_full=false
 run_toplev_execution=false
-run_toplev_cache=false
-run_toplev_memory=false
-run_toplev_ip=false
 run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev-basic)      run_toplev_basic=true ;;
-    --toplev)            run_toplev=true ;;
+    --toplev-full)       run_toplev_full=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
-    --toplev-cache)      run_toplev_cache=true ;;
-    --toplev-memory)     run_toplev_memory=true ;;
-    --toplev-ip)         run_toplev_ip=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
       run_toplev_basic=true
-      run_toplev=false
+      run_toplev_full=false
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
     --long)
       run_toplev_basic=true
-      run_toplev=true
+      run_toplev_full=true
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-cache] [--toplev-memory] [--toplev-ip] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
+    *) echo "Usage: $0 [--toplev-basic] [--toplev-execution] [--toplev-full] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_cache && ! $run_toplev_memory \
-    && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && ! $run_maya && ! $run_pcm; then
   run_toplev_basic=true
-  run_toplev=true
+  run_toplev_full=true
   run_toplev_execution=true
-  run_toplev_cache=true
-  run_toplev_memory=true
-  run_toplev_ip=true
   run_maya=true
   run_pcm=true
 fi
@@ -76,11 +60,8 @@ workload_desc="ID-1 (Seizure Detection – Laelaps)"
 # Announce planned run and provide 10s window to cancel
 tools_list=()
 $run_toplev_basic && tools_list+=("toplev-basic")
-$run_toplev && tools_list+=("toplev")
+$run_toplev_full && tools_list+=("toplev-full")
 $run_toplev_execution && tools_list+=("toplev-execution")
-$run_toplev_cache && tools_list+=("toplev-cache")
-$run_toplev_memory && tools_list+=("toplev-memory")
-$run_toplev_ip && tools_list+=("toplev-ip")
 $run_maya && tools_list+=("maya")
 $run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
@@ -100,16 +81,10 @@ timestamp() {
 # Initialize timing variables
 toplev_basic_start=0
 toplev_basic_end=0
-toplev_start=0
-toplev_end=0
+toplev_full_start=0
+toplev_full_end=0
 toplev_execution_start=0
 toplev_execution_end=0
-toplev_cache_start=0
-toplev_cache_end=0
-toplev_memory_start=0
-toplev_memory_end=0
-toplev_ip_start=0
-toplev_ip_end=0
 maya_start=0
 maya_end=0
 pcm_start=0
@@ -135,15 +110,9 @@ chmod -R a+rx /local
 # Prepare placeholder logs for any disabled tools so that log consolidation
 # works regardless of the selected combination.
 $run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
-$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_full || echo "Toplev-full run skipped" > /local/data/results/done_toplev_full.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
-$run_toplev_cache || \
-  echo "Toplev-cache run skipped" > /local/data/results/done_toplev_cache.log
-$run_toplev_memory || \
-  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
-$run_toplev_ip || \
-  echo "Toplev-ip run skipped" > /local/data/results/done_toplev_ip.log
 $run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
 
@@ -240,11 +209,12 @@ if $run_toplev_basic; then
   toplev_basic_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -l3 -I 500 -v --no-multiplex \
+      -A --per-thread --columns \
+      --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_1_toplev_basic.csv -- \
         taskset -c 6 /local/bci_code/id_1/main \
-          >> /local/data/results/id_1_toplev_basic.log 2>&1
-  '
+          >> /local/data/results/id_1_toplev_basic.log 2>&1'
   toplev_basic_end=$(date +%s)
   echo "Toplev basic profiling finished at: $(timestamp)"
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
@@ -274,87 +244,26 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev cache profiling
-################################################################################
-
-if $run_toplev_cache; then
-  echo "Toplev cache profiling started at: $(timestamp)"
-  toplev_cache_start=$(date +%s)
-  sudo cset shield --exec -- sh -c "
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes '!L1MPKI,L2MPKI,L3MPKI' -x, \
-      -o /local/data/results/id_1_toplev_cache.csv -- \
-        taskset -c 6 /local/bci_code/id_1/main \
-          >> /local/data/results/id_1_toplev_cache.log 2>&1
-  "
-  toplev_cache_end=$(date +%s)
-  echo "Toplev cache profiling finished at: $(timestamp)"
-  toplev_cache_runtime=$((toplev_cache_end - toplev_cache_start))
-  echo "Toplev-cache runtime: $(secs_to_dhm \"$toplev_cache_runtime\")" \
-    > /local/data/results/done_toplev_cache.log
-fi
 
 ################################################################################
-### 9. Toplev memory profiling
+### 8. Toplev full profiling
 ################################################################################
 
-if $run_toplev_memory; then
-  echo "Toplev memory profiling started at: $(timestamp)"
-  toplev_memory_start=$(date +%s)
-  sudo cset shield --exec -- sh -c "
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_1_toplev_memory.csv -- \
-        taskset -c 6 /local/bci_code/id_1/main \
-          >> /local/data/results/id_1_toplev_memory.log 2>&1
-  "
-  toplev_memory_end=$(date +%s)
-  echo "Toplev memory profiling finished at: $(timestamp)"
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_toplev_memory.log
-fi
-
-################################################################################
-### 10. Toplev IP profiling
-################################################################################
-
-if $run_toplev_ip; then
-  echo "Toplev IP profiling started at: $(timestamp)"
-  toplev_ip_start=$(date +%s)
-  sudo cset shield --exec -- sh -c "
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -m --nodes '!IpBranch,IpCall,IpLoad,IpStore' -v -x, \
-      -o /local/data/results/id_1_toplev_ip.csv -- \
-        taskset -c 6 /local/bci_code/id_1/main \
-          >> /local/data/results/id_1_toplev_ip.log 2>&1
-  "
-  toplev_ip_end=$(date +%s)
-  echo "Toplev IP profiling finished at: $(timestamp)"
-  toplev_ip_runtime=$((toplev_ip_end - toplev_ip_start))
-  echo "Toplev-ip runtime: $(secs_to_dhm \"$toplev_ip_runtime\")" \
-    > /local/data/results/done_toplev_ip.log
-fi
-
-################################################################################
-### 11. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  echo "Toplev profiling started at: $(timestamp)"
-  toplev_start=$(date +%s)
+if $run_toplev_full; then
+  echo "Toplev full profiling started at: $(timestamp)"
+  toplev_full_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l6 -I 500 -v --no-multiplex --all -x, \
-      -o /local/data/results/id_1_toplev.csv -- \
+      -o /local/data/results/id_1_toplev_full.csv -- \
         taskset -c 6 /local/bci_code/id_1/main \
-          >> /local/data/results/id_1_toplev.log 2>&1
+          >> /local/data/results/id_1_toplev_full.log 2>&1
   '
-  toplev_end=$(date +%s)
-  echo "Toplev profiling finished at: $(timestamp)"
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_toplev.log
+  toplev_full_end=$(date +%s)
+  echo "Toplev full profiling finished at: $(timestamp)"
+  toplev_full_runtime=$((toplev_full_end - toplev_full_start))
+  echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
+    > /local/data/results/done_toplev_full.log
 fi
 
 ################################################################################
@@ -387,11 +296,8 @@ echo "Experiment finished at: $(timestamp)"
   echo "Done"
   for log in \
       done_toplev_basic.log \
-      done_toplev.log \
+      done_toplev_full.log \
       done_toplev_execution.log \
-      done_toplev_cache.log \
-      done_toplev_memory.log \
-      done_toplev_ip.log \
       done_maya.log \
       done_pcm.log; do
     if [[ -f /local/data/results/$log ]]; then
@@ -402,10 +308,7 @@ echo "Experiment finished at: $(timestamp)"
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev_basic.log \
-      /local/data/results/done_toplev.log \
+      /local/data/results/done_toplev_full.log \
       /local/data/results/done_toplev_execution.log \
-      /local/data/results/done_toplev_cache.log \
-      /local/data/results/done_toplev_memory.log \
-      /local/data/results/done_toplev_ip.log \
       /local/data/results/done_maya.log \
       /local/data/results/done_pcm.log

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -17,55 +17,39 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 # Parse tool selection arguments inside tmux
 run_toplev_basic=false
-run_toplev=false
+run_toplev_full=false
 run_toplev_execution=false
-run_toplev_cache=false
-run_toplev_memory=false
-run_toplev_ip=false
 run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev-basic)      run_toplev_basic=true ;;
-    --toplev)            run_toplev=true ;;
+    --toplev-full)       run_toplev_full=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
-    --toplev-cache)      run_toplev_cache=true ;;
-    --toplev-memory)     run_toplev_memory=true ;;
-    --toplev-ip)         run_toplev_ip=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
       run_toplev_basic=true
-      run_toplev=false
+      run_toplev_full=false
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
     --long)
       run_toplev_basic=true
-      run_toplev=true
+      run_toplev_full=true
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-cache] [--toplev-memory] [--toplev-ip] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
+    *) echo "Usage: $0 [--toplev-basic] [--toplev-execution] [--toplev-full] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_cache && ! $run_toplev_memory \
-    && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && ! $run_maya && ! $run_pcm; then
   run_toplev_basic=true
-  run_toplev=true
+  run_toplev_full=true
   run_toplev_execution=true
-  run_toplev_cache=true
-  run_toplev_memory=true
-  run_toplev_ip=true
   run_maya=true
   run_pcm=true
 fi
@@ -76,11 +60,8 @@ workload_desc="ID-13 (Movement Intent)"
 # Announce planned run and provide 10s window to cancel
 tools_list=()
 $run_toplev_basic && tools_list+=("toplev-basic")
-$run_toplev && tools_list+=("toplev")
+$run_toplev_full && tools_list+=("toplev-full")
 $run_toplev_execution && tools_list+=("toplev-execution")
-$run_toplev_cache && tools_list+=("toplev-cache")
-$run_toplev_memory && tools_list+=("toplev-memory")
-$run_toplev_ip && tools_list+=("toplev-ip")
 $run_maya && tools_list+=("maya")
 $run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
@@ -100,16 +81,10 @@ timestamp() {
 # Initialize timing variables
 toplev_basic_start=0
 toplev_basic_end=0
-toplev_start=0
-toplev_end=0
+toplev_full_start=0
+toplev_full_end=0
 toplev_execution_start=0
 toplev_execution_end=0
-toplev_cache_start=0
-toplev_cache_end=0
-toplev_memory_start=0
-toplev_memory_end=0
-toplev_ip_start=0
-toplev_ip_end=0
 maya_start=0
 maya_end=0
 pcm_start=0
@@ -135,15 +110,9 @@ chmod -R a+rx /local
 # Prepare placeholder logs for any disabled tools so that later consolidation
 # yields a consistent done.log.
 $run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
-$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_full || echo "Toplev-full run skipped" > /local/data/results/done_toplev_full.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
-$run_toplev_cache || \
-  echo "Toplev-cache run skipped" > /local/data/results/done_toplev_cache.log
-$run_toplev_memory || \
-  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
-$run_toplev_ip || \
-  echo "Toplev-ip run skipped" > /local/data/results/done_toplev_ip.log
 $run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
 
@@ -246,7 +215,9 @@ if $run_toplev_basic; then
     export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -l3 -I 500 -v --no-multiplex \
+      -A --per-thread --columns \
+      --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_13_toplev_basic.csv -- \
         taskset -c 6 /local/tools/matlab/bin/matlab \
           -nodisplay -nosplash \
@@ -285,91 +256,14 @@ if $run_toplev_execution; then
     > /local/data/results/done_toplev_execution.log
 fi
 
-################################################################################
-### 8. Toplev cache profiling
-################################################################################
-
-if $run_toplev_cache; then
-  echo "Toplev cache profiling started at: $(timestamp)"
-  toplev_cache_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
-    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
-    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes '!L1MPKI,L2MPKI,L3MPKI' -x, \
-      -o /local/data/results/id_13_toplev_cache.csv -- \
-        taskset -c 6 /local/tools/matlab/bin/matlab \
-          -nodisplay -nosplash \
-          -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
-  ' &> /local/data/results/id_13_toplev_cache.log
-  toplev_cache_end=$(date +%s)
-  echo "Toplev cache profiling finished at: $(timestamp)"
-  toplev_cache_runtime=$((toplev_cache_end - toplev_cache_start))
-  echo "Toplev-cache runtime: $(secs_to_dhm \"$toplev_cache_runtime\")" \
-    > /local/data/results/done_toplev_cache.log
-fi
 
 ################################################################################
-### 9. Toplev memory profiling
+### 8. Toplev full profiling
 ################################################################################
 
-if $run_toplev_memory; then
-  echo "Toplev memory profiling started at: $(timestamp)"
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
-    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
-    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes "!Backend_Bound.Memory_Bound*/3" -x, \
-      -o /local/data/results/id_13_toplev_memory.csv -- \
-        taskset -c 6 /local/tools/matlab/bin/matlab \
-          -nodisplay -nosplash \
-          -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
-  ' &> /local/data/results/id_13_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  echo "Toplev memory profiling finished at: $(timestamp)"
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_toplev_memory.log
-fi
-
-################################################################################
-### 10. Toplev IP profiling
-################################################################################
-
-if $run_toplev_ip; then
-  echo "Toplev IP profiling started at: $(timestamp)"
-  toplev_ip_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
-    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
-    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -m --nodes '!IpBranch,IpCall,IpLoad,IpStore' -v -x, \
-      -o /local/data/results/id_13_toplev_ip.csv -- \
-        taskset -c 6 /local/tools/matlab/bin/matlab \
-          -nodisplay -nosplash \
-          -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
-  ' &> /local/data/results/id_13_toplev_ip.log
-  toplev_ip_end=$(date +%s)
-  echo "Toplev IP profiling finished at: $(timestamp)"
-  toplev_ip_runtime=$((toplev_ip_end - toplev_ip_start))
-  echo "Toplev-ip runtime: $(secs_to_dhm "$toplev_ip_runtime")" \
-    > /local/data/results/done_toplev_ip.log
-fi
-
-################################################################################
-### 11. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  echo "Toplev profiling started at: $(timestamp)"
-  toplev_start=$(date +%s)
+if $run_toplev_full; then
+  echo "Toplev full profiling started at: $(timestamp)"
+  toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
     export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
@@ -377,16 +271,16 @@ if $run_toplev; then
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l6 -I 500 -v --no-multiplex --all -x, \
-      -o /local/data/results/id_13_toplev.csv -- \
+      -o /local/data/results/id_13_toplev_full.csv -- \
         taskset -c 6 /local/tools/matlab/bin/matlab \
           -nodisplay -nosplash \
           -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;"
-  ' &> /local/data/results/id_13_toplev.log
-  toplev_end=$(date +%s)
-  echo "Toplev profiling finished at: $(timestamp)"
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_toplev.log
+  ' &> /local/data/results/id_13_toplev_full.log
+  toplev_full_end=$(date +%s)
+  echo "Toplev full profiling finished at: $(timestamp)"
+  toplev_full_runtime=$((toplev_full_end - toplev_full_start))
+  echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
+    > /local/data/results/done_toplev_full.log
 fi
 
 ################################################################################
@@ -414,11 +308,8 @@ echo "Experiment finished at: $(timestamp)"
   echo "Done"
   for log in \
       done_toplev_basic.log \
-      done_toplev.log \
+      done_toplev_full.log \
       done_toplev_execution.log \
-      done_toplev_cache.log \
-      done_toplev_memory.log \
-      done_toplev_ip.log \
       done_maya.log \
       done_pcm.log; do
     if [[ -f /local/data/results/$log ]]; then
@@ -429,10 +320,7 @@ echo "Experiment finished at: $(timestamp)"
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev_basic.log \
-      /local/data/results/done_toplev.log \
+      /local/data/results/done_toplev_full.log \
       /local/data/results/done_toplev_execution.log \
-      /local/data/results/done_toplev_cache.log \
-      /local/data/results/done_toplev_memory.log \
-      /local/data/results/done_toplev_ip.log \
       /local/data/results/done_maya.log \
       /local/data/results/done_pcm.log

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -17,55 +17,39 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 # Parse tool selection arguments inside tmux
 run_toplev_basic=false
-run_toplev=false
+run_toplev_full=false
 run_toplev_execution=false
-run_toplev_cache=false
-run_toplev_memory=false
-run_toplev_ip=false
 run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev-basic)      run_toplev_basic=true ;;
-    --toplev)            run_toplev=true ;;
+    --toplev-full)       run_toplev_full=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
-    --toplev-cache)      run_toplev_cache=true ;;
-    --toplev-memory)     run_toplev_memory=true ;;
-    --toplev-ip)         run_toplev_ip=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
       run_toplev_basic=true
-      run_toplev=false
+      run_toplev_full=false
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
     --long)
       run_toplev_basic=true
-      run_toplev=true
+      run_toplev_full=true
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-cache] [--toplev-memory] [--toplev-ip] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
+    *) echo "Usage: $0 [--toplev-basic] [--toplev-execution] [--toplev-full] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_cache && ! $run_toplev_memory \
-    && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && ! $run_maya && ! $run_pcm; then
   run_toplev_basic=true
-  run_toplev=true
+  run_toplev_full=true
   run_toplev_execution=true
-  run_toplev_cache=true
-  run_toplev_memory=true
-  run_toplev_ip=true
   run_maya=true
   run_pcm=true
 fi
@@ -76,11 +60,8 @@ workload_desc="ID-20 3gram"
 # Announce planned run and provide 10s window to cancel
 tools_list=()
 $run_toplev_basic && tools_list+=("toplev-basic")
-$run_toplev && tools_list+=("toplev")
+$run_toplev_full && tools_list+=("toplev-full")
 $run_toplev_execution && tools_list+=("toplev-execution")
-$run_toplev_cache && tools_list+=("toplev-cache")
-$run_toplev_memory && tools_list+=("toplev-memory")
-$run_toplev_ip && tools_list+=("toplev-ip")
 $run_maya && tools_list+=("maya")
 $run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
@@ -100,16 +81,10 @@ timestamp() {
 # Initialize timing variables
 toplev_basic_start=0
 toplev_basic_end=0
-toplev_start=0
-toplev_end=0
+toplev_full_start=0
+toplev_full_end=0
 toplev_execution_start=0
 toplev_execution_end=0
-toplev_cache_start=0
-toplev_cache_end=0
-toplev_memory_start=0
-toplev_memory_end=0
-toplev_ip_start=0
-toplev_ip_end=0
 maya_start=0
 maya_end=0
 pcm_start=0
@@ -141,15 +116,9 @@ chmod -R a+rx /local
 # Create placeholder logs for each disabled tool so that the final aggregation
 # step can handle every combination of selected programs.
 $run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
-$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_full || echo "Toplev-full run skipped" > /local/data/results/done_toplev_full.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
-$run_toplev_cache || \
-  echo "Toplev-cache run skipped" > /local/data/results/done_toplev_cache.log
-$run_toplev_memory || \
-  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
-$run_toplev_ip || \
-  echo "Toplev-ip run skipped" > /local/data/results/done_toplev_ip.log
 $run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
 

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -17,55 +17,39 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 # Parse tool selection arguments inside tmux
 run_toplev_basic=false
-run_toplev=false
+run_toplev_full=false
 run_toplev_execution=false
-run_toplev_cache=false
-run_toplev_memory=false
-run_toplev_ip=false
 run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev-basic)      run_toplev_basic=true ;;
-    --toplev)            run_toplev=true ;;
+    --toplev-full)       run_toplev_full=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
-    --toplev-cache)      run_toplev_cache=true ;;
-    --toplev-memory)     run_toplev_memory=true ;;
-    --toplev-ip)         run_toplev_ip=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
       run_toplev_basic=true
-      run_toplev=false
+      run_toplev_full=false
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
     --long)
       run_toplev_basic=true
-      run_toplev=true
+      run_toplev_full=true
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-cache] [--toplev-memory] [--toplev-ip] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
+    *) echo "Usage: $0 [--toplev-basic] [--toplev-execution] [--toplev-full] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_cache && ! $run_toplev_memory \
-    && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && ! $run_maya && ! $run_pcm; then
   run_toplev_basic=true
-  run_toplev=true
+  run_toplev_full=true
   run_toplev_execution=true
-  run_toplev_cache=true
-  run_toplev_memory=true
-  run_toplev_ip=true
   run_maya=true
   run_pcm=true
 fi
@@ -76,11 +60,8 @@ workload_desc="ID-20 3gram LLM"
 # Announce planned run and provide 10s window to cancel
 tools_list=()
 $run_toplev_basic && tools_list+=("toplev-basic")
-$run_toplev && tools_list+=("toplev")
+$run_toplev_full && tools_list+=("toplev-full")
 $run_toplev_execution && tools_list+=("toplev-execution")
-$run_toplev_cache && tools_list+=("toplev-cache")
-$run_toplev_memory && tools_list+=("toplev-memory")
-$run_toplev_ip && tools_list+=("toplev-ip")
 $run_maya && tools_list+=("maya")
 $run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
@@ -100,16 +81,10 @@ timestamp() {
 # Initialize timing variables
 toplev_basic_start=0
 toplev_basic_end=0
-toplev_start=0
-toplev_end=0
+toplev_full_start=0
+toplev_full_end=0
 toplev_execution_start=0
 toplev_execution_end=0
-toplev_cache_start=0
-toplev_cache_end=0
-toplev_memory_start=0
-toplev_memory_end=0
-toplev_ip_start=0
-toplev_ip_end=0
 maya_start=0
 maya_end=0
 pcm_start=0
@@ -141,15 +116,9 @@ chmod -R a+rx /local
 # Prepare placeholder logs for any disabled tool so that done.log contains an
 # entry for every possible stage.
 $run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_llm_toplev_basic.log
-$run_toplev || echo "Toplev run skipped" > /local/data/results/done_llm_toplev.log
+$run_toplev_full || echo "Toplev-full run skipped" > /local/data/results/done_llm_toplev_full.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_llm_toplev_execution.log
-$run_toplev_cache || \
-  echo "Toplev-cache run skipped" > /local/data/results/done_llm_toplev_cache.log
-$run_toplev_memory || \
-  echo "Toplev-memory run skipped" > /local/data/results/done_llm_toplev_memory.log
-$run_toplev_ip || \
-  echo "Toplev-ip run skipped" > /local/data/results/done_llm_toplev_ip.log
 $run_maya || echo "Maya run skipped" > /local/data/results/done_llm_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_llm_pcm.log
 
@@ -357,93 +326,12 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev cache profiling
+### 8. Toplev full profiling
 ################################################################################
 
-if $run_toplev_cache; then
-  echo "Toplev cache profiling started at: $(timestamp)"
-  toplev_cache_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-    . path.sh
-    export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes '!L1MPKI,L2MPKI,L3MPKI' -x, \
-      -o /local/data/results/id_20_3gram_llm_toplev_cache.csv -- \
-        taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  " &> /local/data/results/id_20_3gram_llm_toplev_cache.log
-  toplev_cache_end=$(date +%s)
-  echo "Toplev cache profiling finished at: $(timestamp)"
-  toplev_cache_runtime=$((toplev_cache_end - toplev_cache_start))
-  echo "Toplev-cache runtime: $(secs_to_dhm \"$toplev_cache_runtime\")" \
-    > /local/data/results/done_llm_toplev_cache.log
-fi
-
-################################################################################
-### 9. Toplev memory profiling
-################################################################################
-
-if $run_toplev_memory; then
-  echo "Toplev memory profiling started at: $(timestamp)"
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev_memory.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  " &> /local/data/results/id_20_3gram_llm_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  echo "Toplev memory profiling finished at: $(timestamp)"
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_llm_toplev_memory.log
-fi
-
-################################################################################
-### 10. Toplev IP profiling
-################################################################################
-
-if $run_toplev_ip; then
-  echo "Toplev IP profiling started at: $(timestamp)"
-  toplev_ip_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -m --nodes '!IpBranch,IpCall,IpLoad,IpStore' -v -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev_ip.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-        --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-        --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  " &> /local/data/results/id_20_3gram_llm_toplev_ip.log
-  toplev_ip_end=$(date +%s)
-  echo "Toplev IP profiling finished at: $(timestamp)"
-  toplev_ip_runtime=$((toplev_ip_end - toplev_ip_start))
-  echo "Toplev-ip runtime: $(secs_to_dhm "$toplev_ip_runtime")" \
-    > /local/data/results/done_llm_toplev_ip.log
-fi
-
-################################################################################
-### 11. Toplev profiling
-################################################################################
-
-if $run_toplev; then
+if $run_toplev_full; then
   echo "Toplev profiling started at: $(timestamp)"
-  toplev_start=$(date +%s)
+  toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -452,16 +340,16 @@ if $run_toplev; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_llm_toplev.csv -- \
+    -o /local/data/results/id_20_3gram_llm_toplev_full.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
         --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-  ' &> /local/data/results/id_20_3gram_llm_toplev.log
-  toplev_end=$(date +%s)
-  echo "Toplev profiling finished at: $(timestamp)"
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_llm_toplev.log
+  ' >> /local/data/results/id_20_3gram_llm_toplev_full.log 2>&1
+  toplev_full_end=$(date +%s)
+  echo "Toplev full profiling finished at: $(timestamp)"
+  toplev_full_runtime=$((toplev_full_end - toplev_full_start))
+  echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
+    > /local/data/results/done_llm_toplev_full.log
 fi
 ################################################################################
 ### 11. Convert Maya raw output files into CSV
@@ -489,11 +377,10 @@ echo "Experiment finished at: $(timestamp)"
   echo "Done"
   for log in \
       done_llm_toplev_basic.log \
-      done_llm_toplev.log \
+      done_llm_toplev_full.log \
+      done_llm_toplev_basic.log \
+      done_llm_toplev_full.log \
       done_llm_toplev_execution.log \
-      done_llm_toplev_cache.log \
-      done_llm_toplev_memory.log \
-      done_llm_toplev_ip.log \
       done_llm_maya.log \
       done_llm_pcm.log; do
     if [[ -f /local/data/results/$log ]]; then
@@ -504,10 +391,7 @@ echo "Experiment finished at: $(timestamp)"
 } > /local/data/results/done_llm.log
 
 rm -f /local/data/results/done_llm_toplev_basic.log \
-      /local/data/results/done_llm_toplev.log \
+      /local/data/results/done_llm_toplev_full.log \
       /local/data/results/done_llm_toplev_execution.log \
-      /local/data/results/done_llm_toplev_cache.log \
-      /local/data/results/done_llm_toplev_memory.log \
-      /local/data/results/done_llm_toplev_ip.log \
       /local/data/results/done_llm_maya.log \
       /local/data/results/done_llm_pcm.log

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -16,51 +16,40 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 
 # Parse tool selection arguments inside tmux
-run_toplev=false
+run_toplev_basic=false
+run_toplev_full=false
 run_toplev_execution=false
-run_toplev_cache=false
-run_toplev_memory=false
-run_toplev_ip=false
 run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --toplev)            run_toplev=true ;;
+    --toplev-basic)      run_toplev_basic=true ;;
+    --toplev-full)       run_toplev_full=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
-    --toplev-cache)      run_toplev_cache=true ;;
-    --toplev-memory)     run_toplev_memory=true ;;
-    --toplev-ip)         run_toplev_ip=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
-      run_toplev=false
+      run_toplev_basic=true
+      run_toplev_full=false
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
     --long)
-      run_toplev=true
+      run_toplev_basic=true
+      run_toplev_full=true
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-cache] [--toplev-memory] [--toplev-ip] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
+    *) echo "Usage: $0 [--toplev-basic] [--toplev-execution] [--toplev-full] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_cache && ! $run_toplev_memory \
-    && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
-  run_toplev=true
+if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && ! $run_maya && ! $run_pcm; then
+  run_toplev_basic=true
+  run_toplev_full=true
   run_toplev_execution=true
-  run_toplev_cache=true
-  run_toplev_memory=true
-  run_toplev_ip=true
   run_maya=true
   run_pcm=true
 fi
@@ -70,11 +59,9 @@ workload_desc="ID-20 3gram RNN"
 
 # Announce planned run and provide 10s window to cancel
 tools_list=()
-$run_toplev && tools_list+=("toplev")
+$run_toplev_basic && tools_list+=("toplev-basic")
+$run_toplev_full && tools_list+=("toplev-full")
 $run_toplev_execution && tools_list+=("toplev-execution")
-$run_toplev_cache && tools_list+=("toplev-cache")
-$run_toplev_memory && tools_list+=("toplev-memory")
-$run_toplev_ip && tools_list+=("toplev-ip")
 $run_maya && tools_list+=("maya")
 $run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
@@ -92,16 +79,12 @@ timestamp() {
 }
 
 # Initialize timing variables
-toplev_start=0
-toplev_end=0
+toplev_basic_start=0
+toplev_basic_end=0
+toplev_full_start=0
+toplev_full_end=0
 toplev_execution_start=0
 toplev_execution_end=0
-toplev_cache_start=0
-toplev_cache_end=0
-toplev_memory_start=0
-toplev_memory_end=0
-toplev_ip_start=0
-toplev_ip_end=0
 maya_start=0
 maya_end=0
 pcm_start=0
@@ -132,15 +115,10 @@ chmod -R a+rx /local
 
 # Create placeholder logs whenever a tool is disabled so the final summary is
 # predictable regardless of the chosen subset.
-$run_toplev || echo "Toplev run skipped" > /local/data/results/done_rnn_toplev.log
+$run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_rnn_toplev_basic.log
+$run_toplev_full || echo "Toplev-full run skipped" > /local/data/results/done_rnn_toplev_full.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_rnn_toplev_execution.log
-$run_toplev_cache || \
-  echo "Toplev-cache run skipped" > /local/data/results/done_rnn_toplev_cache.log
-$run_toplev_memory || \
-  echo "Toplev-memory run skipped" > /local/data/results/done_rnn_toplev_memory.log
-$run_toplev_ip || \
-  echo "Toplev-ip run skipped" > /local/data/results/done_rnn_toplev_ip.log
 $run_maya || echo "Maya run skipped" > /local/data/results/done_rnn_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_rnn_pcm.log
 
@@ -296,7 +274,37 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev execution profiling
+### 6. Toplev basic profiling
+################################################################################
+
+if $run_toplev_basic; then
+  echo "Toplev basic profiling started at: $(timestamp)"
+  toplev_basic_start=$(date +%s)
+  sudo -E cset shield --exec -- bash -lc '
+  source /local/tools/bci_env/bin/activate
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+  . path.sh
+  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+  taskset -c 5 /local/tools/pmu-tools/toplev \
+    -l3 -I 500 -v --no-multiplex \
+    -A --per-thread --columns \
+    --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
+    -o /local/data/results/id_20_3gram_rnn_toplev_basic.csv -- \
+      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        --datasetPath=/local/data/ptDecoder_ctc \
+        --modelPath=/local/data/speechBaseline4/ \
+        >> /local/data/results/id_20_3gram_rnn_toplev_basic.log 2>&1
+  '
+  toplev_basic_end=$(date +%s)
+  echo "Toplev basic profiling finished at: $(timestamp)"
+  toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
+  echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
+    > /local/data/results/done_rnn_toplev_basic.log
+fi
+
+################################################################################
+### 7. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -323,112 +331,31 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 7. Toplev cache profiling
+### 8. Toplev full profiling
 ################################################################################
 
-if $run_toplev_cache; then
-  echo "Toplev cache profiling started at: $(timestamp)"
-  toplev_cache_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -v --nodes '!L1MPKI,L2MPKI,L3MPKI' -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev_cache.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  " &> /local/data/results/id_20_3gram_rnn_toplev_cache.log
-  toplev_cache_end=$(date +%s)
-  echo "Toplev cache profiling finished at: $(timestamp)"
-  toplev_cache_runtime=$((toplev_cache_end - toplev_cache_start))
-  echo "Toplev-cache runtime: $(secs_to_dhm \"$toplev_cache_runtime\")" \
-    > /local/data/results/done_rnn_toplev_cache.log
-fi
-
-################################################################################
-### 8. Toplev memory profiling
-################################################################################
-
-if $run_toplev_memory; then
-  echo "Toplev memory profiling started at: $(timestamp)"
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev_memory.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  " &> /local/data/results/id_20_3gram_rnn_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  echo "Toplev memory profiling finished at: $(timestamp)"
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_rnn_toplev_memory.log
-fi
-
-################################################################################
-### 9. Toplev IP profiling
-################################################################################
-
-if $run_toplev_ip; then
-  echo "Toplev IP profiling started at: $(timestamp)"
-  toplev_ip_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH='${LD_LIBRARY_PATH:-}'
-  . path.sh
-  export PYTHONPATH='$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}'
-
-  taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -m --nodes '!IpBranch,IpCall,IpLoad,IpStore' -v -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev_ip.csv -- \
-      taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-        --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  " &> /local/data/results/id_20_3gram_rnn_toplev_ip.log
-  toplev_ip_end=$(date +%s)
-  echo "Toplev IP profiling finished at: $(timestamp)"
-  toplev_ip_runtime=$((toplev_ip_end - toplev_ip_start))
-  echo "Toplev-ip runtime: $(secs_to_dhm "$toplev_ip_runtime")" \
-    > /local/data/results/done_rnn_toplev_ip.log
-fi
-
-################################################################################
-### 10. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  echo "Toplev profiling started at: $(timestamp)"
-  toplev_start=$(date +%s)
+if $run_toplev_full; then
+  echo "Toplev full profiling started at: $(timestamp)"
+  toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-toplev_end=$(date +%s)
   taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l6 -I 500 -v --no-multiplex --all -x, \
-    -o /local/data/results/id_20_3gram_rnn_toplev.csv -- \
+    -l6 -I 500 --no-multiplex --all -x, \
+    -o /local/data/results/id_20_3gram_rnn_toplev_full.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
         --datasetPath=/local/data/ptDecoder_ctc \
-        --modelPath=/local/data/speechBaseline4/
-  ' &> /local/data/results/id_20_3gram_rnn_toplev.log
-  toplev_end=$(date +%s)
-  echo "Toplev profiling finished at: $(timestamp)"
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_rnn_toplev.log
+        --modelPath=/local/data/speechBaseline4/ \
+        >> /local/data/results/id_20_3gram_rnn_toplev_full.log 2>&1
+  '
+  toplev_full_end=$(date +%s)
+  echo "Toplev full profiling finished at: $(timestamp)"
+  toplev_full_runtime=$((toplev_full_end - toplev_full_start))
+  echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
+    > /local/data/results/done_rnn_toplev_full.log
 fi
 ################################################################################
 ### 10. Convert Maya raw output files into CSV
@@ -453,14 +380,12 @@ echo "Experiment finished at: $(timestamp)"
 ################################################################################
 {
   echo "Done"
-  for log in \
-      done_rnn_toplev.log \
-      done_rnn_toplev_execution.log \
-      done_rnn_toplev_cache.log \
-      done_rnn_toplev_memory.log \
-      done_rnn_toplev_ip.log \
-      done_rnn_maya.log \
-      done_rnn_pcm.log; do
+    for log in \
+        done_rnn_toplev_basic.log \
+        done_rnn_toplev_full.log \
+        done_rnn_toplev_execution.log \
+        done_rnn_maya.log \
+        done_rnn_pcm.log; do
     if [[ -f /local/data/results/$log ]]; then
       echo
       cat /local/data/results/$log
@@ -468,10 +393,8 @@ echo "Experiment finished at: $(timestamp)"
   done
 } > /local/data/results/done_rnn.log
 
-rm -f /local/data/results/done_rnn_toplev.log \
+rm -f /local/data/results/done_rnn_toplev_basic.log \
+      /local/data/results/done_rnn_toplev_full.log \
       /local/data/results/done_rnn_toplev_execution.log \
-      /local/data/results/done_rnn_toplev_cache.log \
-      /local/data/results/done_rnn_toplev_memory.log \
-      /local/data/results/done_rnn_toplev_ip.log \
       /local/data/results/done_rnn_maya.log \
       /local/data/results/done_rnn_pcm.log

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -17,55 +17,39 @@ exec > >(tee -a /local/logs/run.log) 2>&1
 
 # Parse tool selection arguments inside tmux
 run_toplev_basic=false
-run_toplev=false
+run_toplev_full=false
 run_toplev_execution=false
-run_toplev_cache=false
-run_toplev_memory=false
-run_toplev_ip=false
 run_maya=false
 run_pcm=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --toplev-basic)      run_toplev_basic=true ;;
-    --toplev)            run_toplev=true ;;
+    --toplev-full)       run_toplev_full=true ;;
     --toplev-execution)  run_toplev_execution=true ;;
-    --toplev-cache)      run_toplev_cache=true ;;
-    --toplev-memory)     run_toplev_memory=true ;;
-    --toplev-ip)         run_toplev_ip=true ;;
     --maya)              run_maya=true ;;
     --pcm)               run_pcm=true ;;
     --short)
       run_toplev_basic=true
-      run_toplev=false
+      run_toplev_full=false
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
     --long)
       run_toplev_basic=true
-      run_toplev=true
+      run_toplev_full=true
       run_toplev_execution=true
-      run_toplev_cache=true
-      run_toplev_memory=true
-      run_toplev_ip=true
       run_maya=true
       run_pcm=true
       ;;
-    *) echo "Usage: $0 [--toplev] [--toplev-execution] [--toplev-cache] [--toplev-memory] [--toplev-ip] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
+    *) echo "Usage: $0 [--toplev-basic] [--toplev-execution] [--toplev-full] [--maya] [--pcm] [--short] [--long]" >&2; exit 1 ;;
   esac
   shift
 done
-if ! $run_toplev_basic && ! $run_toplev && ! $run_toplev_execution && ! $run_toplev_cache && ! $run_toplev_memory \
-    && ! $run_toplev_ip && ! $run_maya && ! $run_pcm; then
+if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && ! $run_maya && ! $run_pcm; then
   run_toplev_basic=true
-  run_toplev=true
+  run_toplev_full=true
   run_toplev_execution=true
-  run_toplev_cache=true
-  run_toplev_memory=true
-  run_toplev_ip=true
   run_maya=true
   run_pcm=true
 fi
@@ -76,11 +60,8 @@ workload_desc="ID-3 (Compression)"
 # Announce planned run and provide 10s window to cancel
 tools_list=()
 $run_toplev_basic && tools_list+=("toplev-basic")
-$run_toplev && tools_list+=("toplev")
+$run_toplev_full && tools_list+=("toplev-full")
 $run_toplev_execution && tools_list+=("toplev-execution")
-$run_toplev_cache && tools_list+=("toplev-cache")
-$run_toplev_memory && tools_list+=("toplev-memory")
-$run_toplev_ip && tools_list+=("toplev-ip")
 $run_maya && tools_list+=("maya")
 $run_pcm  && tools_list+=("pcm")
 tool_msg=$(IFS=, ; echo "${tools_list[*]}")
@@ -100,16 +81,10 @@ timestamp() {
 # Initialize timing variables
 toplev_basic_start=0
 toplev_basic_end=0
-toplev_start=0
-toplev_end=0
+toplev_full_start=0
+toplev_full_end=0
 toplev_execution_start=0
 toplev_execution_end=0
-toplev_cache_start=0
-toplev_cache_end=0
-toplev_memory_start=0
-toplev_memory_end=0
-toplev_ip_start=0
-toplev_ip_end=0
 maya_start=0
 maya_end=0
 pcm_start=0
@@ -143,15 +118,9 @@ chmod -R a+rx /local
 # Create placeholder logs for disabled tools so that done.log always lists
 # every profiling stage.
 $run_toplev_basic || echo "Toplev-basic run skipped" > /local/data/results/done_toplev_basic.log
-$run_toplev || echo "Toplev run skipped" > /local/data/results/done_toplev.log
+$run_toplev_full || echo "Toplev-full run skipped" > /local/data/results/done_toplev_full.log
 $run_toplev_execution || \
   echo "Toplev-execution run skipped" > /local/data/results/done_toplev_execution.log
-$run_toplev_cache || \
-  echo "Toplev-cache run skipped" > /local/data/results/done_toplev_cache.log
-$run_toplev_memory || \
-  echo "Toplev-memory run skipped" > /local/data/results/done_toplev_memory.log
-$run_toplev_ip || \
-  echo "Toplev-ip run skipped" > /local/data/results/done_toplev_ip.log
 $run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
 
@@ -277,7 +246,9 @@ if $run_toplev_basic; then
     source /local/tools/compression_env/bin/activate
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+      -l3 -I 500 -v --no-multiplex \
+      -A --per-thread --columns \
+      --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_3_toplev_basic.csv -- \
         taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac
   ' &> /local/data/results/id_3_toplev_basic.log
@@ -311,92 +282,28 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev cache profiling
-################################################################################
-
-if $run_toplev_cache; then
-  echo "Toplev cache profiling started at: $(timestamp)"
-  toplev_cache_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/compression_env/bin/activate
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -v --nodes '!L1MPKI,L2MPKI,L3MPKI' -x, \
-      -o /local/data/results/id_3_toplev_cache.csv -- \
-        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac
-  " &>  /local/data/results/id_3_toplev_cache.log
-  toplev_cache_end=$(date +%s)
-  echo "Toplev cache profiling finished at: $(timestamp)"
-  toplev_cache_runtime=$((toplev_cache_end - toplev_cache_start))
-  echo "Toplev-cache runtime: $(secs_to_dhm \"$toplev_cache_runtime\")" \
-    > /local/data/results/done_toplev_cache.log
-fi
 
 ################################################################################
-### 9. Toplev memory profiling
+### 8. Toplev full profiling
 ################################################################################
 
-if $run_toplev_memory; then
-  echo "Toplev memory profiling started at: $(timestamp)"
-  toplev_memory_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/compression_env/bin/activate
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l3 -I 500 -v --nodes '!Backend_Bound.Memory_Bound*/3' -x, \
-      -o /local/data/results/id_3_toplev_memory.csv -- \
-        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac
-  " &>  /local/data/results/id_3_toplev_memory.log
-  toplev_memory_end=$(date +%s)
-  echo "Toplev memory profiling finished at: $(timestamp)"
-  toplev_memory_runtime=$((toplev_memory_end - toplev_memory_start))
-  echo "Toplev-memory runtime: $(secs_to_dhm "$toplev_memory_runtime")" \
-    > /local/data/results/done_toplev_memory.log
-fi
-
-################################################################################
-### 10. Toplev IP profiling
-################################################################################
-
-if $run_toplev_ip; then
-  echo "Toplev IP profiling started at: $(timestamp)"
-  toplev_ip_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc "
-    source /local/tools/compression_env/bin/activate
-
-    taskset -c 5 /local/tools/pmu-tools/toplev \
-      -l0 -I 500 -m --nodes '!IpBranch,IpCall,IpLoad,IpStore' -v -x, \
-      -o /local/data/results/id_3_toplev_ip.csv -- \
-        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac
-  " &>  /local/data/results/id_3_toplev_ip.log
-  toplev_ip_end=$(date +%s)
-  echo "Toplev IP profiling finished at: $(timestamp)"
-  toplev_ip_runtime=$((toplev_ip_end - toplev_ip_start))
-  echo "Toplev-ip runtime: $(secs_to_dhm "$toplev_ip_runtime")" \
-    > /local/data/results/done_toplev_ip.log
-fi
-
-################################################################################
-### 11. Toplev profiling
-################################################################################
-
-if $run_toplev; then
-  echo "Toplev profiling started at: $(timestamp)"
-  toplev_start=$(date +%s)
+if $run_toplev_full; then
+  echo "Toplev full profiling started at: $(timestamp)"
+  toplev_full_start=$(date +%s)
 
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/compression_env/bin/activate
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l6 -I 500 -v --no-multiplex --all -x, \
-      -o /local/data/results/id_3_toplev.csv -- \
+      -o /local/data/results/id_3_toplev_full.csv -- \
         taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac
-  ' &>  /local/data/results/id_3_toplev.log
-  toplev_end=$(date +%s)
-  echo "Toplev profiling finished at: $(timestamp)"
-  toplev_runtime=$((toplev_end - toplev_start))
-  echo "Toplev runtime: $(secs_to_dhm "$toplev_runtime")" \
-    > /local/data/results/done_toplev.log
+  ' &>  /local/data/results/id_3_toplev_full.log
+  toplev_full_end=$(date +%s)
+  echo "Toplev full profiling finished at: $(timestamp)"
+  toplev_full_runtime=$((toplev_full_end - toplev_full_start))
+  echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
+    > /local/data/results/done_toplev_full.log
 fi
 
 ################################################################################
@@ -425,11 +332,8 @@ echo "Experiment finished at: $(timestamp)"
   echo "Done"
   for log in \
       done_toplev_basic.log \
-      done_toplev.log \
+      done_toplev_full.log \
       done_toplev_execution.log \
-      done_toplev_cache.log \
-      done_toplev_memory.log \
-      done_toplev_ip.log \
       done_maya.log \
       done_pcm.log; do
     if [[ -f /local/data/results/$log ]]; then
@@ -440,10 +344,7 @@ echo "Experiment finished at: $(timestamp)"
 } > /local/data/results/done.log
 
 rm -f /local/data/results/done_toplev_basic.log \
-      /local/data/results/done_toplev.log \
+      /local/data/results/done_toplev_full.log \
       /local/data/results/done_toplev_execution.log \
-      /local/data/results/done_toplev_cache.log \
-      /local/data/results/done_toplev_memory.log \
-      /local/data/results/done_toplev_ip.log \
       /local/data/results/done_maya.log \
       /local/data/results/done_pcm.log


### PR DESCRIPTION
## Summary
- update instructions about toplev modes in `AGENTS.md`
- switch 20-segment helper scripts to use `toplev-full`
- remove old cache/memory/ip profiling
- add missing toplev-basic sections where needed

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_3.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh` *(unchanged)*
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_686b623bb8fc832c8707c0afc962938f