### PR TITLE
Fix toplev basic options for 3gram scripts

### DIFF
--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -332,7 +332,9 @@ if $run_toplev_basic; then
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -l3 -I 500 -v --no-multiplex \
+    -A --per-thread --columns \
+    --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_rnn_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
         --datasetPath=/local/data/ptDecoder_ctc \
@@ -347,7 +349,9 @@ if $run_toplev_basic; then
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -l3 -I 500 -v --no-multiplex \
+    -A --per-thread --columns \
+    --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_lm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
         --lmDir=/local/data/languageModel/ \
@@ -362,7 +366,9 @@ if $run_toplev_basic; then
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -l3 -I 500 -v --no-multiplex \
+    -A --per-thread --columns \
+    --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -285,7 +285,9 @@ if $run_toplev_basic; then
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
-    -l0 -I 500 -v --nodes "!Instructions,CPI" -x, \
+    -l3 -I 500 -v --no-multiplex \
+    -A --per-thread --columns \
+    --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \


### PR DESCRIPTION
## Summary
- update `run_20_3gram.sh` and `run_20_3gram_llm.sh` to use the same toplev-basic configuration as the other run scripts
- confirm the other scripts already pass the correct `--nodes` list and options

## Testing
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_686b6e60d310832c9b05deed5f1408e9