### PR TITLE
Fix path in run_13.sh

### DIFF
--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -117,9 +117,9 @@ $run_maya || echo "Maya run skipped" > /local/data/results/done_maya.log
 $run_pcm || echo "PCM run skipped" > /local/data/results/done_pcm.log
 
 ################################################################################
-### 2. Change into the BCI project directory
+### 2. Change into the home directory
 ################################################################################
-cd /local/tools/bci_project
+cd ~
 
 ################################################################################
 ### 3. PCM profiling


### PR DESCRIPTION
## Summary
- ensure run_13.sh changes into the home directory rather than a non-existent bci_project folder

## Testing
- `shellcheck -x scripts/run_13.sh | head`

------
https://chatgpt.com/codex/tasks/task_e_686ebcf81494832c97ac344fdf817bff