### PR TITLE
Fix MATLAB load handling for ID-13

### DIFF
--- a/id_13/README
+++ b/id_13/README
@@ -1,5 +1,9 @@
 ID-13: Movement Intent
 
+The MATLAB function `motor_movement` expects the input `.mat` file to
+contain a struct named `data`. This struct must include a `trial` field
+with the recorded signal for each trial.
+
 ## Runtime Phases
 
 During execution, the script prints log lines of the form:

--- a/id_13/motor_movement.m
+++ b/id_13/motor_movement.m
@@ -17,7 +17,12 @@ function motor_movement(dataPath, libPath)
     log_phase('LOAD','START');
     tStart = cputime;
     %load('S5_raw_segmented.mat');
-    load(dataPath)
+    tmp = load(dataPath);
+    if isfield(tmp, 'data')
+        data = tmp.data;
+    else
+        error("%s does not contain variable 'data'", dataPath);
+    end
     log_phase('LOAD','END');
     
     addpath(libPath);


### PR DESCRIPTION
## Summary
- ensure `motor_movement` assigns the `data` struct explicitly
- document expected MAT-file structure for ID‑13

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ee25cf0c4832c84532280b9aa63e1