### PR TITLE
Improve PCM logging granularity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ tools/maya/            – microarchitectural profiler (C++)
 5. **Style clean‑up** – apply clang‑format or black where appropriate.
 
 6. **Timestamp logging** – after the 10-second countdown, each run script must print `Experiment started at: YYYY-MM-DD - hh:mm` and when complete print `Experiment finished at: YYYY-MM-DD - hh:mm`.  Major profiling stages should also announce their start and end times.
+   Each PCM tool (pcm, pcm-memory, pcm-power and pcm-pcie) reports its own start and finish times.
 7. **User permissions** – before changing ownership of `/local`, run scripts must set:
    ```bash
    RUN_USER=${SUDO_USER:-$(id -un)}

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -89,6 +89,12 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
+pcm_memory_start=0
+pcm_memory_end=0
+pcm_power_start=0
+pcm_power_end=0
+pcm_pcie_start=0
+pcm_pcie_end=0
 
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
@@ -126,9 +132,10 @@ cd ~
 ################################################################################
 
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm \
       -csv=/local/data/results/id_1_pcm.csv \
@@ -136,6 +143,11 @@ if $run_pcm; then
       taskset -c 6 /local/bci_code/id_1/main \
     >>/local/data/results/id_1_pcm.log 2>&1
   '
+  pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
+
+  echo "pcm-memory started at: $(timestamp)"
+  pcm_memory_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
       -csv=/local/data/results/id_1_pcm_memory.csv \
@@ -143,6 +155,11 @@ if $run_pcm; then
       taskset -c 6 /local/bci_code/id_1/main \
     >>/local/data/results/id_1_pcm_memory.log 2>&1
   '
+  pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
+
+  echo "pcm-power started at: $(timestamp)"
+  pcm_power_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
@@ -150,6 +167,11 @@ if $run_pcm; then
       taskset -c 6 /local/bci_code/id_1/main \
     >>/local/data/results/id_1_pcm_power.log 2>&1
   '
+  pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
+
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
       -csv=/local/data/results/id_1_pcm_pcie.csv \
@@ -157,11 +179,20 @@ if $run_pcm; then
       taskset -c 6 /local/bci_code/id_1/main \
     >>/local/data/results/id_1_pcm_pcie.log 2>&1
   '
-  pcm_end=$(date +%s)
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
-  echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")" \
-    > /local/data/results/done_pcm.log
+  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
+  pcm_power_runtime=$((pcm_power_end - pcm_power_start))
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  {
+    echo "pcm runtime:        $(secs_to_dhm "$pcm_runtime")"
+    echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "pcm-power runtime:  $(secs_to_dhm "$pcm_power_runtime")"
+    echo "pcm-pcie runtime:   $(secs_to_dhm "$pcm_pcie_runtime")"
+  } > /local/data/results/done_pcm.log
 fi
 
 ################################################################################

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -89,6 +89,12 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
+pcm_memory_start=0
+pcm_memory_end=0
+pcm_power_start=0
+pcm_power_end=0
+pcm_pcie_start=0
+pcm_pcie_end=0
 
 # Format seconds as "Xd Yh Zm"
 secs_to_dhm() {
@@ -126,9 +132,10 @@ cd ~
 ################################################################################
 ################################################################################
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm \
       -csv=/local/data/results/id_13_pcm.csv \
@@ -136,6 +143,11 @@ if $run_pcm; then
       taskset -c 6 /local/tools/matlab/bin/matlab -nodisplay -nosplash -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
     >>/local/data/results/id_13_pcm.log 2>&1
   '
+  pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
+
+  echo "pcm-memory started at: $(timestamp)"
+  pcm_memory_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
       -csv=/local/data/results/id_13_pcm_memory.csv \
@@ -143,6 +155,11 @@ if $run_pcm; then
       taskset -c 6 /local/tools/matlab/bin/matlab -nodisplay -nosplash -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
     >>/local/data/results/id_13_pcm_memory.log 2>&1
   '
+  pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
+
+  echo "pcm-power started at: $(timestamp)"
+  pcm_power_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
@@ -150,6 +167,11 @@ if $run_pcm; then
       taskset -c 6 /local/tools/matlab/bin/matlab -nodisplay -nosplash -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
     >>/local/data/results/id_13_pcm_power.log 2>&1
   '
+  pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
+
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
       -csv=/local/data/results/id_13_pcm_pcie.csv \
@@ -157,11 +179,19 @@ if $run_pcm; then
       taskset -c 6 /local/tools/matlab/bin/matlab -nodisplay -nosplash -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
     >>/local/data/results/id_13_pcm_pcie.log 2>&1
   '
-  pcm_end=$(date +%s)
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
+  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
+  pcm_power_runtime=$((pcm_power_end - pcm_power_start))
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   {
-    echo "PCM runtime:    $(secs_to_dhm "$pcm_runtime")"
+    echo "pcm runtime:        $(secs_to_dhm "$pcm_runtime")"
+    echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")"
+    echo "pcm-power runtime:  $(secs_to_dhm "$pcm_power_runtime")"
+    echo "pcm-pcie runtime:   $(secs_to_dhm "$pcm_pcie_runtime")"
   } > /local/data/results/done_pcm.log
 fi
 

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -140,9 +140,10 @@ export PYTHONPATH=$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:$PYTHONPATH
 ################################################################################
 
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -162,7 +163,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_pcm.log 2>&1
   pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
 
+  echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -183,7 +186,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_pcm_memory.log 2>&1
   pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
 
+  echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -204,7 +209,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_pcm_power.log 2>&1
   pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
 
+  echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -225,6 +232,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -132,9 +132,10 @@ cd /local/tools/bci_project
 ################################################################################
 
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -154,7 +155,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_pcm.log 2>&1
   pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
 
+  echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -175,7 +178,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_pcm_memory.log 2>&1
   pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
 
+  echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -196,7 +201,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_pcm_power.log 2>&1
   pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
 
+  echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -217,6 +224,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -131,9 +131,10 @@ cd /local/tools/bci_project
 ### 3. PCM profiling
 ################################################################################
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -153,7 +154,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_llm_pcm.log 2>&1
   pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
 
+  echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -174,7 +177,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_llm_pcm_memory.log 2>&1
   pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
 
+  echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -195,7 +200,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_llm_pcm_power.log 2>&1
   pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
 
+  echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -216,6 +223,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_llm_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -131,9 +131,10 @@ cd /local/tools/bci_project
 ### 3. PCM profiling
 ################################################################################
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -153,7 +154,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_lm_pcm.log 2>&1
   pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
 
+  echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -174,7 +177,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_lm_pcm_memory.log 2>&1
   pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
 
+  echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -195,7 +200,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_lm_pcm_power.log 2>&1
   pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
 
+  echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -216,6 +223,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_lm_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -131,9 +131,10 @@ cd /local/tools/bci_project
 ### 3. PCM profiling
 ################################################################################
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -153,7 +154,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_rnn_pcm.log 2>&1
   pcm_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
 
+  echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -174,7 +177,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_rnn_pcm_memory.log 2>&1
   pcm_memory_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
 
+  echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -195,7 +200,9 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_rnn_pcm_power.log 2>&1
   pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
 
+  echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -216,6 +223,7 @@ if $run_pcm; then
       "
   ' >>/local/data/results/id_20_3gram_rnn_pcm_pcie.log 2>&1
   pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))
   pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -136,9 +136,10 @@ source /local/tools/compression_env/bin/activate
 ################################################################################
 ################################################################################
 if $run_pcm; then
-  echo "PCM profiling started at: $(timestamp)"
-  pcm_start=$(date +%s)
   sudo modprobe msr
+
+  echo "pcm started at: $(timestamp)"
+  pcm_start=$(date +%s)
   pcm_gen_start=$(date +%s)
   sudo bash -lc '
     source /local/tools/compression_env/bin/activate
@@ -150,6 +151,9 @@ if $run_pcm; then
     >>/local/data/results/id_3_pcm.log 2>&1
   '
   pcm_gen_end=$(date +%s)
+  echo "pcm finished at: $(timestamp)"
+
+  echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo bash -lc '
     source /local/tools/compression_env/bin/activate
@@ -161,6 +165,9 @@ if $run_pcm; then
     >>/local/data/results/id_3_pcm_memory.log 2>&1
   '
   pcm_mem_end=$(date +%s)
+  echo "pcm-memory finished at: $(timestamp)"
+
+  echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo bash -lc '
     source /local/tools/compression_env/bin/activate
@@ -172,6 +179,9 @@ if $run_pcm; then
     >>/local/data/results/id_3_pcm_power.log 2>&1
   '
   pcm_power_end=$(date +%s)
+  echo "pcm-power finished at: $(timestamp)"
+
+  echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo bash -lc '
     source /local/tools/compression_env/bin/activate
@@ -183,6 +193,7 @@ if $run_pcm; then
     >>/local/data/results/id_3_pcm_pcie.log 2>&1
   '
   pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
   pcm_end=$(date +%s)
   echo "PCM profiling finished at: $(timestamp)"
   pcm_runtime=$((pcm_end - pcm_start))


### PR DESCRIPTION
## Summary
- add per-tool start/finish logging in all run scripts
- record individual PCM runtimes
- document PCM logging behavior in `AGENTS.md`

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20.sh`
- `bash -n scripts/run_20_3gram.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`
- `bash -n scripts/run_3.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ef70bd064832cb2dc57d3787ede71