### PR TITLE
Handle missing benchmark CSV files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,3 +105,5 @@ scripts set this to files such as `id_3_pcm.csv` or `id_3_toplev_basic.csv` so
 each profiling tool keeps its own CSV. When no path is supplied, the script
 creates `benchmark-lossless-<dataset>-<duration>-<compressor>.csv` inside
 `results/`.
+CSV helpers in `id_3/code/utils.py` automatically return an empty DataFrame when
+the file is missing or empty so repeated runs start with a clean slate.

--- a/id_3/code/scripts/benchmark-lossless-delta.py
+++ b/id_3/code/scripts/benchmark-lossless-delta.py
@@ -35,7 +35,7 @@ from wavpack_numcodecs import WavPack
 this_folder = Path(__file__).parent
 sys.path.append(str(this_folder.parent))
 
-from utils import append_to_csv, is_entry
+from utils import append_to_csv, is_entry, read_csv_if_exists
 
 start_time = time.time()
 
@@ -208,8 +208,8 @@ if __name__ == "__main__":
                 if benchmark_file.is_file():
                     benchmark_file.unlink()
             else:
-                if benchmark_file.is_file():
-                    df = pd.read_csv(benchmark_file, index_col=False)
+                if benchmark_file.is_file() and benchmark_file.stat().st_size > 0:
+                    df = read_csv_if_exists(benchmark_file, index_col=False)
                     print(f"Number of existing entries: {len(df)}")
 
             # loop over sessions in dataset

--- a/id_3/code/scripts/benchmark-lossless-preprocessing.py
+++ b/id_3/code/scripts/benchmark-lossless-preprocessing.py
@@ -32,7 +32,7 @@ this_folder = Path(__file__).parent
 sys.path.append(str(this_folder.parent))
 
 from flac_numcodecs import Flac
-from utils import append_to_csv, gs_download_folder, is_entry
+from utils import append_to_csv, gs_download_folder, is_entry, read_csv_if_exists
 from wavpack_numcodecs import WavPack
 
 overwrite = False
@@ -223,8 +223,8 @@ if __name__ == "__main__":
                 if benchmark_file.is_file():
                     benchmark_file.unlink()
             else:
-                if benchmark_file.is_file():
-                    df = pd.read_csv(benchmark_file, index_col=False)
+                if benchmark_file.is_file() and benchmark_file.stat().st_size > 0:
+                    df = read_csv_if_exists(benchmark_file, index_col=False)
                     print(f"Number of existing entries: {len(df)}")
 
             # loop over sessions in dataset

--- a/id_3/code/scripts/benchmark-lossless.py
+++ b/id_3/code/scripts/benchmark-lossless.py
@@ -33,7 +33,7 @@ this_folder = Path(__file__).parent
 sys.path.append(str(this_folder.parent))
 
 from flac_numcodecs import Flac
-from utils import append_to_csv, gs_download_folder, is_entry
+from utils import append_to_csv, gs_download_folder, is_entry, read_csv_if_exists
 from wavpack_numcodecs import WavPack
 
 overwrite = False
@@ -241,8 +241,8 @@ if __name__ == "__main__":
                     if benchmark_file.is_file():
                         benchmark_file.unlink()
                 else:
-                    if benchmark_file.is_file():
-                        df = pd.read_csv(benchmark_file, index_col=False)
+                    if benchmark_file.is_file() and benchmark_file.stat().st_size > 0:
+                        df = read_csv_if_exists(benchmark_file, index_col=False)
                         print(f"Number of existing entries: {len(df)}")
 
                 # loop over sessions in dataset

--- a/id_3/code/scripts/benchmark-lossy-exp.py
+++ b/id_3/code/scripts/benchmark-lossy-exp.py
@@ -35,7 +35,13 @@ from wavpack_numcodecs import WavPack
 # add utils to path
 this_folder = Path(__file__).parent
 sys.path.append(str(this_folder.parent))
-from utils import append_to_csv, benchmark_lossy_compression, is_entry, trunc_filter
+from utils import (
+    append_to_csv,
+    benchmark_lossy_compression,
+    is_entry,
+    trunc_filter,
+    read_csv_if_exists,
+)
 
 start_time = time.time()
 
@@ -230,8 +236,8 @@ if __name__ == "__main__":
 
                 benchmark_file = results_folder / f"benchmark-lossy-exp-{dset}-{strategy}-{factor}.csv"
 
-                if benchmark_file.is_file():
-                    df = pd.read_csv(benchmark_file, index_col=False)
+                if benchmark_file.is_file() and benchmark_file.stat().st_size > 0:
+                    df = read_csv_if_exists(benchmark_file, index_col=False)
                 else:
                     df = None
 
@@ -412,7 +418,7 @@ if __name__ == "__main__":
                 elapsed_session = np.round(t_stop_session - t_start_session)
                 print(f"\n\t\tElapsed time session: {elapsed_session}s")
 
-            df = pd.read_csv(benchmark_file, index_col=False)
+            df = read_csv_if_exists(benchmark_file, index_col=False)
             print(f"\n\tFinal # entries in results for {strategy}: {len(df)}")
 
             t_stop_strategy = time.perf_counter()
@@ -431,7 +437,7 @@ if __name__ == "__main__":
     if len(csv_files) > 1:
         for csv_file in csv_files:
             print(f"Aggregating {csv_file.name}")
-            df_single = pd.read_csv(csv_file, index_col=False)
+            df_single = read_csv_if_exists(csv_file, index_col=False)
             df = df_single if df is None else pd.concat((df, df_single))
 
         if df is not None:
@@ -442,7 +448,7 @@ if __name__ == "__main__":
             csv_file.unlink()
 
     # compute spike sorting comparisons against lossless
-    res_lossy = pd.read_csv(results_folder / "benchmark-lossy-exp.csv", index_col=False)
+    res_lossy = read_csv_if_exists(results_folder / "benchmark-lossy-exp.csv", index_col=False)
     sessions = np.unique(res_lossy.session)
     sortings_folder = raw_sorting_outputs_folder
 

--- a/id_3/code/scripts/benchmark-lossy-sim.py
+++ b/id_3/code/scripts/benchmark-lossy-sim.py
@@ -31,7 +31,13 @@ from wavpack_numcodecs import WavPack
 # add utils to path
 this_folder = Path(__file__).parent
 sys.path.append(str(this_folder.parent))
-from utils import append_to_csv, benchmark_lossy_compression, is_entry, trunc_filter
+from utils import (
+    append_to_csv,
+    benchmark_lossy_compression,
+    is_entry,
+    trunc_filter,
+    read_csv_if_exists,
+)
 
 start_time = time.time()
 
@@ -396,7 +402,7 @@ if __name__ == "__main__":
         df = None
         for sorting_csv_file in csv_sorting_files:
             print(f"Aggregating {sorting_csv_file.name}")
-            df_single = pd.read_csv(sorting_csv_file, index_col=False)
+            df_single = read_csv_if_exists(sorting_csv_file, index_col=False)
             df = df_single if df is None else pd.concat((df, df_single))
             sorting_csv_file.unlink()
         df.to_csv(benchmark_file, index=False)
@@ -417,7 +423,7 @@ if __name__ == "__main__":
             df_wfs = None
             for i, wf_csv_file in enumerate(csv_wfs_probe_files):
                 print(f"Aggregating {wf_csv_file.name}")
-                df_single = pd.read_csv(wf_csv_file, index_col=False)
+                df_single = read_csv_if_exists(wf_csv_file, index_col=False)
                 df_wfs = df_single if df_wfs is None else df_wfs.merge(df_single, on=on)
                 wf_csv_file.unlink()
             df_probes.append(df_wfs)

--- a/id_3/code/utils.py
+++ b/id_3/code/utils.py
@@ -10,6 +10,29 @@ import numcodecs
 import spikeinterface.preprocessing as spre
 
 
+def read_csv_if_exists(csv_file, **kwargs):
+    """Safely read a CSV file.
+
+    Parameters
+    ----------
+    csv_file : str or Path
+        CSV path to load.
+    **kwargs : any
+        Additional arguments passed to :func:`pandas.read_csv`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with file contents or empty DataFrame if the file is missing
+        or empty.
+    """
+
+    csv_file = Path(csv_file)
+    if csv_file.is_file() and csv_file.stat().st_size > 0:
+        return pd.read_csv(csv_file, **kwargs)
+    return pd.DataFrame()
+
+
 def is_notebook() -> bool:
     """Checks if Python is running in a Jupyter notebook
 
@@ -48,8 +71,8 @@ def is_entry(csv_file, entry, subset_columns=None):
     bool
         True if entry is already in the dataframe, False otherwise
     """
-    if csv_file.is_file():
-        df = pd.read_csv(csv_file)
+    if csv_file.is_file() and csv_file.stat().st_size > 0:
+        df = read_csv_if_exists(csv_file)
         if subset_columns is None:
             subset_columns = list(entry.keys())
 
@@ -93,8 +116,8 @@ def append_to_csv(csv_file, new_entry, subset_columns=None, verbose=False):
         If True, it prints whether the new entry was successfull, by default False
     """
     new_df = None
-    if csv_file.is_file():
-        df_benchmark = pd.read_csv(csv_file, index_col=False)
+    if csv_file.is_file() and csv_file.stat().st_size > 0:
+        df_benchmark = read_csv_if_exists(csv_file, index_col=False)
         if not is_entry(csv_file, new_entry, subset_columns):
             new_data_arr = {k: [v] for k, v in new_entry.items()}
             new_df = pd.concat([df_benchmark, pd.DataFrame(new_data_arr)])


### PR DESCRIPTION
## Summary
- add a `read_csv_if_exists` helper that returns an empty DataFrame if the file is missing or empty
- use the safe CSV loader across benchmark scripts
- document that CSV helpers skip absent files

## Testing
- `python -m py_compile id_3/code/utils.py id_3/code/scripts/benchmark-lossless.py id_3/code/scripts/benchmark-lossless-delta.py id_3/code/scripts/benchmark-lossy-sim.py id_3/code/scripts/benchmark-lossless-preprocessing.py id_3/code/scripts/benchmark-lossy-exp.py`
- `pip install --user numcodecs`

------
https://chatgpt.com/codex/tasks/task_e_68753f0e3bd0832cb20b3317dfcb764f