### PR TITLE
Fix ID-3 csv mixing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,12 @@ PCM profiling flags follow the same pattern. Use `--pcm`, `--pcm-memory`,
 them all (the default when no PCM options are provided).
 
 `benchmark-lossless.py` no longer aggregates individual CSV files. It appends
-results to the path provided as an optional fourth command-line argument. Run
-scripts set this to files such as `id_3_pcm.csv` or `id_3_toplev_basic.csv` so
-each profiling tool keeps its own CSV. When no path is supplied, the script
-creates `benchmark-lossless-<dataset>-<duration>-<compressor>.csv` inside
+results to the path provided as an optional fourth command-line argument.
+Run scripts now supply dedicated workload files for each tool, e.g.,
+`workload_pcm.csv` or `workload_toplev_basic.csv`, so compression metrics stay
+separate from profiler outputs like `id_3_pcm.csv` or
+`id_3_toplev_basic.csv`. When no path is supplied, the script creates
+`benchmark-lossless-<dataset>-<duration>-<compressor>.csv` inside
 `results/`.
 CSV helpers in `id_3/code/utils.py` automatically return an empty DataFrame when
 the file is missing or empty so repeated runs start with a clean slate.

--- a/id_3/code/README.md
+++ b/id_3/code/README.md
@@ -51,9 +51,10 @@ Alternatively, arguments can be specified with a JSON file containing the same k
 
 If `csv_path` is provided, results are appended to that file. When omitted,
 the default name is `benchmark-lossless-<dataset>-<chunk_duration>-<compressor>.csv`
-inside the `results/` folder. The run scripts pass paths such as
-`id_3_pcm.csv` or `id_3_toplev_basic.csv` so each profiling tool keeps its
-own CSV.
+inside the `results/` folder. The run scripts supply dedicated workload
+files such as `workload_pcm.csv` or `workload_toplev_basic.csv` so
+compression results stay separate from profiler CSVs like `id_3_pcm.csv`
+or `id_3_toplev_basic.csv`.
 
 
 

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -178,7 +178,7 @@ if $run_pcm; then
     taskset -c 5 /local/tools/pcm/build/bin/pcm \
       -csv=/local/data/results/id_3_pcm.csv \
       0.5 -- \
-      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_pcm.csv \
+      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm.csv \
     >>/local/data/results/id_3_pcm.log 2>&1
   '
   pcm_gen_end=$(date +%s)
@@ -197,7 +197,7 @@ if $run_pcm_memory; then
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
       -csv=/local/data/results/id_3_pcm_memory.csv \
       0.5 -- \
-      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_pcm_memory.csv \
+      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm_memory.csv \
     >>/local/data/results/id_3_pcm_memory.log 2>&1
   '
   pcm_mem_end=$(date +%s)
@@ -216,7 +216,7 @@ if $run_pcm_power; then
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
       -csv=/local/data/results/id_3_pcm_power.csv -- \
-      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_pcm_power.csv \
+      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm_power.csv \
     >>/local/data/results/id_3_pcm_power.log 2>&1
   '
   pcm_power_end=$(date +%s)
@@ -235,7 +235,7 @@ if $run_pcm_pcie; then
     taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
       -csv=/local/data/results/id_3_pcm_pcie.csv \
       -B 1.0 -- \
-      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_pcm_pcie.csv \
+      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm_pcie.csv \
     >>/local/data/results/id_3_pcm_pcie.log 2>&1
   '
   pcm_pcie_end=$(date +%s)
@@ -273,7 +273,7 @@ if $run_maya; then
     MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
     # Run the workload pinned to CPU 6
-    taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_maya.csv \
+    taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_maya.csv \
       >> /local/data/results/id_3_maya.log 2>&1
 
     kill "$MAYA_PID"
@@ -300,7 +300,7 @@ if $run_toplev_basic; then
       -A --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_3_toplev_basic.csv -- \
-        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_toplev_basic.csv
+        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_toplev_basic.csv
   ' &> /local/data/results/id_3_toplev_basic.log
   toplev_basic_end=$(date +%s)
   echo "Toplev basic profiling finished at: $(timestamp)"
@@ -322,7 +322,7 @@ if $run_toplev_execution; then
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l1 -I 500 -v -x, \
       -o /local/data/results/id_3_toplev_execution.csv -- \
-        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_toplev_execution.csv
+        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_toplev_execution.csv
   ' &>  /local/data/results/id_3_toplev_execution.log
   toplev_execution_end=$(date +%s)
   echo "Toplev execution profiling finished at: $(timestamp)"
@@ -345,7 +345,7 @@ if $run_toplev_full; then
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l6 -I 500 -v --no-multiplex --all -x, \
       -o /local/data/results/id_3_toplev_full.csv -- \
-        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/id_3_toplev_full.csv
+        taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_toplev_full.csv
   ' &>  /local/data/results/id_3_toplev_full.log
   toplev_full_end=$(date +%s)
   echo "Toplev full profiling finished at: $(timestamp)"


### PR DESCRIPTION
## Summary
- clarify that each tool uses its own workload csv
- store workload results in `workload_<tool>.csv`

## Testing
- `bash -n scripts/run_3.sh`
- `pytest -q id_3`

------
https://chatgpt.com/codex/tasks/task_e_6876a48d9b44832c808cd6109e724a5f