### PR TITLE
Install energy policy helper in startup scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ An example `setup.sh` lives at repo root and installs:
 * GCC, make, cmake, ninja‑build
 * Python3.10 + venv + scientific wheels (torch, numpy, scipy, numba, etc.)
 * libomp‑dev for OpenMP
+* x86-energy-perf-policy for runtime energy policy control
 * (optional) clone FieldTrip for MATLAB users – *skip on CI*
   Total runtime fits within the 10‑minute constraint on a 4‑core Ubuntu 24.04 VM.
 

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 
 ################################################################################
 

--- a/scripts/startup_1.sh
+++ b/scripts/startup_1.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 
 ################################################################################
 

--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -168,6 +168,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential ppp pptp-linux cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 
 ################################################################################
 

--- a/scripts/startup_20.sh
+++ b/scripts/startup_20.sh
@@ -142,9 +142,11 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cmake
+sudo apt-get install -y git build-essential cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 # Install necessary packages
-sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
+sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget
 
 ################################################################################
 

--- a/scripts/startup_20_3gram.sh
+++ b/scripts/startup_20_3gram.sh
@@ -142,9 +142,11 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cmake
+sudo apt-get install -y git build-essential cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 # Install necessary packages
-sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
+sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget
 
 ################################################################################
 

--- a/scripts/startup_20_5gram.sh
+++ b/scripts/startup_20_5gram.sh
@@ -142,9 +142,11 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cmake
+sudo apt-get install -y git build-essential cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 # Install necessary packages
-sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
+sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget
 
 ################################################################################
 

--- a/scripts/startup_3.sh
+++ b/scripts/startup_3.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cpuset cmake
+# Install energy policy helper used at runtime (cpupower comes from linux-tools below)
+sudo apt-get install -y x86-energy-perf-policy
 
 ################################################################################
 


### PR DESCRIPTION
## Summary
- ensure all workload startup scripts install the x86-energy-perf-policy helper
- document energy policy requirement in AGENTS guide

## Testing
- `bash -n scripts/startup.sh && bash -n scripts/startup_1.sh && bash -n scripts/startup_3.sh && bash -n scripts/startup_13.sh && bash -n scripts/startup_20.sh && bash -n scripts/startup_20_3gram.sh && bash -n scripts/startup_20_5gram.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897782fc548832c94e0775d5914d3dc