### PR TITLE
Add idle power settle step to all run scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,7 @@ separate from profiler outputs like `id_3_pcm.csv` or
 `results/`.
 CSV helpers in `id_3/code/utils.py` automatically return an empty DataFrame when
 the file is missing or empty so repeated runs start with a clean slate.
+
+Run scripts include a baseline settle helper that waits for package power (and
+optionally temperature) to remain below configurable idle thresholds before
+each measurement stage. A short note is logged only if the helper times out.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -274,6 +274,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -282,6 +373,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo sh -c '
@@ -299,6 +391,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo sh -c '
@@ -316,6 +409,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo sh -c '
@@ -333,6 +427,7 @@ if $run_pcm_power; then
 fi
 
 if $run_pcm_pcie; then
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -366,6 +461,7 @@ if $run_pcm_pcie; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
@@ -386,6 +482,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  wait_for_idle "maya"
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
@@ -416,6 +513,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
@@ -438,6 +536,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
@@ -459,6 +558,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo cset shield --exec -- sh -c '

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -258,6 +258,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -266,6 +357,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -288,6 +380,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
@@ -310,6 +403,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -332,6 +426,7 @@ if $run_pcm_power; then
 fi
 
 if $run_pcm_pcie; then
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -369,6 +464,7 @@ if $run_pcm_pcie; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm \"$pcm_pcie_runtime\")" > /local/data/results/done_pcm_pcie.log
@@ -388,6 +484,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  wait_for_idle "maya"
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -419,6 +516,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -447,6 +545,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -473,6 +572,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -265,6 +265,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -273,7 +364,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
-
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -300,6 +391,7 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
 
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
@@ -326,6 +418,7 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
     > /local/data/results/done_pcm_memory.log
 
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -352,6 +445,7 @@ if $run_pcm; then
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
 
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -394,6 +488,7 @@ if $run_pcm; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
@@ -414,6 +509,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  wait_for_idle "maya"
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -477,6 +573,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
 
@@ -528,6 +625,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   # RNN script
@@ -572,6 +670,7 @@ fi
 ### 9. Toplev full profiling
 ################################################################################
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
 

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -258,6 +258,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -266,7 +357,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
-
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -293,6 +384,7 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
 
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
@@ -319,6 +411,7 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
     > /local/data/results/done_pcm_memory.log
 
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -345,6 +438,7 @@ if $run_pcm; then
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
 
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -387,6 +481,7 @@ if $run_pcm; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
@@ -407,7 +502,8 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
-echo "Maya profiling started at: $(timestamp)"
+  wait_for_idle "maya"
+  echo "Maya profiling started at: $(timestamp)"
 maya_start=$(date +%s)
 
 # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -486,6 +582,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
 
@@ -552,6 +649,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -608,6 +706,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -258,6 +258,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -266,7 +357,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
-
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -293,6 +384,7 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_llm_pcm.log
 
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
@@ -319,6 +411,7 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
     > /local/data/results/done_llm_pcm_memory.log
 
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -345,6 +438,7 @@ if $run_pcm; then
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_llm_pcm_power.log
 
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -387,6 +481,7 @@ if $run_pcm; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
@@ -407,6 +502,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  wait_for_idle "maya"
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -442,6 +538,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -471,6 +568,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -498,6 +596,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -274,6 +274,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -282,7 +373,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
-
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -309,6 +400,7 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_rnn_pcm.log
 
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
@@ -335,6 +427,7 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
     > /local/data/results/done_rnn_pcm_memory.log
 
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -361,6 +454,7 @@ if $run_pcm; then
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_rnn_pcm_power.log
 
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -405,6 +499,7 @@ if $run_pcm; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
@@ -425,6 +520,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  wait_for_idle "maya"
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -462,6 +558,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -492,6 +589,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -519,6 +617,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -278,6 +278,97 @@ echo -n "Online CPUs: "
 cat /sys/devices/system/cpu/online
 
 ################################################################################
+### Baseline settle helper (quiet unless timeout)
+###      - Wait until package power <= IDLE_PKG_W for IDLE_STABLE_FOR seconds
+###      - Optional: also require package temp <= IDLE_TEMP_C (if >0 and readable)
+###      - Timeout after IDLE_MAX_WAIT seconds and log a short note
+################################################################################
+# Tunables (override via env if needed)
+IDLE_PKG_W=${IDLE_PKG_W:-6}            # watts threshold considered "idle"
+IDLE_STABLE_FOR=${IDLE_STABLE_FOR:-15} # seconds at/below threshold to accept
+IDLE_MAX_WAIT=${IDLE_MAX_WAIT:-180}    # overall timeout (seconds)
+IDLE_TEMP_C=${IDLE_TEMP_C:-50}         # 0 disables temp check; else require <= this
+
+rapl_pkg_dir=/sys/class/powercap/intel-rapl:0
+rapl_energy=$rapl_pkg_dir/energy_uj
+rapl_max=$rapl_pkg_dir/max_energy_range_uj
+
+read_pkg_power_w() {
+  # 1 second integration of RAPL energy to compute watts; handle wrap
+  local e1 t1 e2 t2 max de dt
+  e1=$(<"$rapl_energy") || return 1
+  t1=$(date +%s%N)
+  sleep 1
+  e2=$(<"$rapl_energy") || return 1
+  t2=$(date +%s%N)
+  max=$(<"$rapl_max" 2>/dev/null || echo 0)
+  de=$((e2 - e1))
+  if (( de < 0 && max > 0 )); then
+    de=$((de + max))
+  fi
+  dt=$((t2 - t1)) # ns
+  awk -v de="$de" -v dt="$dt" 'BEGIN{ printf "%.3f", (de/1e6)/(dt/1e9) }'
+}
+
+find_pkg_temp_input() {
+  # Try to find "Package id 0" sensor from coretemp
+  local d lbl inp
+  for d in /sys/class/hwmon/hwmon*; do
+    [[ -r "$d/name" && "$(cat "$d/name")" == "coretemp" ]] || continue
+    for lbl in "$d"/temp*_label; do
+      [[ -r "$lbl" ]] || continue
+      if grep -qi "package id 0" "$lbl"; then
+        inp="${lbl/_label/_input}"
+        [[ -r "$inp" ]] && echo "$inp" && return 0
+      fi
+    done
+  done
+  return 1
+}
+
+wait_for_idle() {
+  local who="$1"          # label for logs if we time out
+  local stable=0 waited=0 p=0.0 tC=""
+  local pkg_temp_path; pkg_temp_path=$(find_pkg_temp_input || true)
+
+  while (( waited < IDLE_MAX_WAIT )); do
+    p=$(read_pkg_power_w || echo 999)
+
+    if awk -v p="$p" -v th="$IDLE_PKG_W" 'BEGIN{exit (p<=th)?0:1}'; then
+      power_ok=1
+    else
+      power_ok=0
+    fi
+
+    temp_ok=1
+    if (( IDLE_TEMP_C > 0 )) && [[ -n "$pkg_temp_path" ]]; then
+      local t_mC; t_mC=$(<"$pkg_temp_path" 2>/dev/null || echo 0)
+      tC=$((t_mC/1000))
+      (( tC <= IDLE_TEMP_C )) || temp_ok=0
+    fi
+
+    if (( power_ok == 1 && temp_ok == 1 )); then
+      ((stable++))
+      (( stable >= IDLE_STABLE_FOR )) && break
+    else
+      stable=0
+    fi
+
+    sleep 1
+    ((waited++))
+  done
+
+  if (( waited >= IDLE_MAX_WAIT )); then
+    # Only print on timeout (keep logs quiet otherwise)
+    if [[ -n "$tC" ]]; then
+      echo "Note: idle settle timeout before ${who} (power≈${p}W, temp≈${tC}°C)"
+    else
+      echo "Note: idle settle timeout before ${who} (power≈${p}W)"
+    fi
+  fi
+}
+
+################################################################################
 ### 4. PCM profiling
 ################################################################################
 
@@ -286,6 +377,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  wait_for_idle "pcm"
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   pcm_gen_start=$(date +%s)
@@ -306,6 +398,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  wait_for_idle "pcm-memory"
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo bash -lc '
@@ -325,6 +418,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  wait_for_idle "pcm-power"
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo bash -lc '
@@ -344,6 +438,7 @@ if $run_pcm_power; then
 fi
 
 if $run_pcm_pcie; then
+  wait_for_idle "pcm-pcie (pre)"
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
 
@@ -379,6 +474,7 @@ if $run_pcm_pcie; then
   disable_siblings_except_self "$WORK_CPU"
 
   pcm_pcie_end=$(date +%s)
+  wait_for_idle "pcm-pcie (post-restore)"
   echo "pcm-pcie finished at: $(timestamp)"
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
@@ -399,6 +495,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  wait_for_idle "maya"
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -429,6 +526,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  wait_for_idle "toplev-basic"
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -453,6 +551,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  wait_for_idle "toplev-execution"
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -475,6 +574,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  wait_for_idle "toplev-full"
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
 


### PR DESCRIPTION
## Summary
- add baseline settle helper using RAPL power/temperature before measurements
- call `wait_for_idle` for PCM, Maya, and Toplev stages in every run script
- document idle settle requirement in AGENTS guide

## Testing
- `shellcheck bci_code/scripts/run_1.sh bci_code/scripts/run_3.sh bci_code/scripts/run_13.sh bci_code/scripts/run_20.sh bci_code/scripts/run_20_3gram.sh bci_code/scripts/run_20_3gram_lm.sh bci_code/scripts/run_20_3gram_llm.sh bci_code/scripts/run_20_3gram_rnn.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897dd565500832c8daccf2a53247acf