### PR TITLE
Add idle cooldown helper before profiling tools

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -128,6 +128,34 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  # Configurable thresholds (safe defaults)
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"            # seconds minimum idle
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}" # 50C in millideg
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"             # absolute cap
+  local SLEEP_STEP=3
+  local waited=0
+
+  # 1) Minimum idle time
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+
+  # 2) Temperature-based settle with timeout (skip if sensor missing)
+  if [ -r "${TEMP_PATH}" ]; then
+    while true; do
+      local t
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        break
+      fi
+      [ "$waited" -ge "$MAX_WAIT" ] && break
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  fi
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -166,6 +194,7 @@ fi
 
 if $run_pcm; then
   echo "pcm started at: $(timestamp)"
+  idle_wait
   pcm_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm \
@@ -183,6 +212,7 @@ fi
 
 if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
+  idle_wait
   pcm_memory_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
@@ -200,6 +230,7 @@ fi
 
 if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
+  idle_wait
   pcm_power_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
@@ -217,6 +248,7 @@ fi
 
 if $run_pcm_pcie; then
   echo "pcm-pcie started at: $(timestamp)"
+  idle_wait
   pcm_pcie_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
@@ -248,6 +280,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 
 if $run_maya; then
   echo "Maya profiling started at: $(timestamp)"
+  idle_wait
   maya_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     # Start Maya on core 5 in background, log raw output
@@ -278,6 +311,7 @@ fi
 
 if $run_toplev_basic; then
   echo "Toplev basic profiling started at: $(timestamp)"
+  idle_wait
   toplev_basic_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
@@ -300,6 +334,7 @@ fi
 
 if $run_toplev_execution; then
   echo "Toplev execution profiling started at: $(timestamp)"
+  idle_wait
   toplev_execution_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
@@ -321,6 +356,7 @@ fi
 
 if $run_toplev_full; then
   echo "Toplev full profiling started at: $(timestamp)"
+  idle_wait
   toplev_full_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -128,6 +128,34 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  # Configurable thresholds (safe defaults)
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"            # seconds minimum idle
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}" # 50C in millideg
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"             # absolute cap
+  local SLEEP_STEP=3
+  local waited=0
+
+  # 1) Minimum idle time
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+
+  # 2) Temperature-based settle with timeout (skip if sensor missing)
+  if [ -r "${TEMP_PATH}" ]; then
+    while true; do
+      local t
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        break
+      fi
+      [ "$waited" -ge "$MAX_WAIT" ] && break
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  fi
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -167,6 +195,7 @@ fi
 
 if $run_pcm; then
   echo "pcm started at: $(timestamp)"
+  idle_wait
   pcm_start=$(date +%s)
   sudo -E bash -lc '
     taskset -c 5 /local/tools/pcm/build/bin/pcm \
@@ -189,6 +218,7 @@ fi
 
 if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
+  idle_wait
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
@@ -211,6 +241,7 @@ fi
 
 if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
+  idle_wait
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
@@ -233,6 +264,7 @@ fi
 
 if $run_pcm_pcie; then
   echo "pcm-pcie started at: $(timestamp)"
+  idle_wait
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
@@ -266,6 +298,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 
 if $run_maya; then
   echo "Maya profiling started at: $(timestamp)"
+  idle_wait
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -297,6 +330,7 @@ fi
 
 if $run_toplev_basic; then
   echo "Toplev basic profiling started at: $(timestamp)"
+  idle_wait
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -325,6 +359,7 @@ fi
 
 if $run_toplev_execution; then
   echo "Toplev execution profiling started at: $(timestamp)"
+  idle_wait
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
@@ -351,6 +386,7 @@ fi
 
 if $run_toplev_full; then
   echo "Toplev full profiling started at: $(timestamp)"
+  idle_wait
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -128,6 +128,34 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  # Configurable thresholds (safe defaults)
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"            # seconds minimum idle
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}" # 50C in millideg
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"             # absolute cap
+  local SLEEP_STEP=3
+  local waited=0
+
+  # 1) Minimum idle time
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+
+  # 2) Temperature-based settle with timeout (skip if sensor missing)
+  if [ -r "${TEMP_PATH}" ]; then
+    while true; do
+      local t
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        break
+      fi
+      [ "$waited" -ge "$MAX_WAIT" ] && break
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  fi
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -167,6 +195,7 @@ fi
 if $run_pcm; then
 
   echo "pcm started at: $(timestamp)"
+  idle_wait
   pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -193,6 +222,7 @@ if $run_pcm; then
     > /local/data/results/done_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
+  idle_wait
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -219,6 +249,7 @@ if $run_pcm; then
     > /local/data/results/done_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"
+  idle_wait
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -245,6 +276,7 @@ if $run_pcm; then
     > /local/data/results/done_pcm_power.log
 
   echo "pcm-pcie started at: $(timestamp)"
+  idle_wait
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -287,6 +319,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 
 if $run_maya; then
 echo "Maya profiling started at: $(timestamp)"
+idle_wait
 maya_start=$(date +%s)
 
 # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -366,6 +399,7 @@ fi
 
 if $run_toplev_basic; then
   echo "Toplev basic profiling started at: $(timestamp)"
+  idle_wait
   toplev_basic_start=$(date +%s)
 
   # RNN script
@@ -432,6 +466,7 @@ fi
 
 if $run_toplev_execution; then
   echo "Toplev execution profiling started at: $(timestamp)"
+  idle_wait
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -488,6 +523,7 @@ fi
 
 if $run_toplev_full; then
   echo "Toplev full profiling started at: $(timestamp)"
+  idle_wait
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -128,6 +128,34 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  # Configurable thresholds (safe defaults)
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"            # seconds minimum idle
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}" # 50C in millideg
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"             # absolute cap
+  local SLEEP_STEP=3
+  local waited=0
+
+  # 1) Minimum idle time
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+
+  # 2) Temperature-based settle with timeout (skip if sensor missing)
+  if [ -r "${TEMP_PATH}" ]; then
+    while true; do
+      local t
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        break
+      fi
+      [ "$waited" -ge "$MAX_WAIT" ] && break
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  fi
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -167,6 +195,7 @@ fi
 if $run_pcm; then
 
   echo "pcm started at: $(timestamp)"
+  idle_wait
   pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -193,6 +222,7 @@ if $run_pcm; then
     > /local/data/results/done_llm_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
+  idle_wait
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -219,6 +249,7 @@ if $run_pcm; then
     > /local/data/results/done_llm_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"
+  idle_wait
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -245,6 +276,7 @@ if $run_pcm; then
     > /local/data/results/done_llm_pcm_power.log
 
   echo "pcm-pcie started at: $(timestamp)"
+  idle_wait
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -287,6 +319,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 
 if $run_maya; then
   echo "Maya profiling started at: $(timestamp)"
+  idle_wait
   maya_start=$(date +%s)
 
   # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -322,6 +355,7 @@ fi
 
 if $run_toplev_basic; then
   echo "Toplev basic profiling started at: $(timestamp)"
+  idle_wait
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -351,6 +385,7 @@ fi
 
 if $run_toplev_execution; then
   echo "Toplev execution profiling started at: $(timestamp)"
+  idle_wait
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -378,6 +413,7 @@ fi
 
 if $run_toplev_full; then
   echo "Toplev profiling started at: $(timestamp)"
+  idle_wait
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -128,6 +128,34 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  # Configurable thresholds (safe defaults)
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"            # seconds minimum idle
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}" # 50C in millideg
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"             # absolute cap
+  local SLEEP_STEP=3
+  local waited=0
+
+  # 1) Minimum idle time
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+
+  # 2) Temperature-based settle with timeout (skip if sensor missing)
+  if [ -r "${TEMP_PATH}" ]; then
+    while true; do
+      local t
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        break
+      fi
+      [ "$waited" -ge "$MAX_WAIT" ] && break
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  fi
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -167,6 +195,7 @@ fi
 if $run_pcm; then
 
   echo "pcm started at: $(timestamp)"
+  idle_wait
   pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -193,6 +222,7 @@ if $run_pcm; then
     > /local/data/results/done_lm_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
+  idle_wait
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -219,6 +249,7 @@ if $run_pcm; then
     > /local/data/results/done_lm_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"
+  idle_wait
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -245,6 +276,7 @@ if $run_pcm; then
     > /local/data/results/done_lm_pcm_power.log
 
   echo "pcm-pcie started at: $(timestamp)"
+  idle_wait
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -287,6 +319,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 
 if $run_maya; then
   echo "Maya profiling started at: $(timestamp)"
+  idle_wait
   maya_start=$(date +%s)
 
   # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -322,6 +355,7 @@ fi
 
 if $run_toplev_basic; then
   echo "Toplev basic profiling started at: $(timestamp)"
+  idle_wait
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -352,6 +386,7 @@ fi
 
 if $run_toplev_execution; then
   echo "Toplev execution profiling started at: $(timestamp)"
+  idle_wait
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -379,6 +414,7 @@ fi
 
 if $run_toplev_full; then
   echo "Toplev profiling started at: $(timestamp)"
+  idle_wait
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -128,6 +128,34 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  # Configurable thresholds (safe defaults)
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"            # seconds minimum idle
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}" # 50C in millideg
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"             # absolute cap
+  local SLEEP_STEP=3
+  local waited=0
+
+  # 1) Minimum idle time
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+
+  # 2) Temperature-based settle with timeout (skip if sensor missing)
+  if [ -r "${TEMP_PATH}" ]; then
+    while true; do
+      local t
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        break
+      fi
+      [ "$waited" -ge "$MAX_WAIT" ] && break
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  fi
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -167,6 +195,7 @@ fi
 if $run_pcm; then
 
   echo "pcm started at: $(timestamp)"
+  idle_wait
   pcm_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -193,6 +222,7 @@ if $run_pcm; then
     > /local/data/results/done_rnn_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
+  idle_wait
   pcm_memory_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -219,6 +249,7 @@ if $run_pcm; then
     > /local/data/results/done_rnn_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"
+  idle_wait
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -245,6 +276,7 @@ if $run_pcm; then
     > /local/data/results/done_rnn_pcm_power.log
 
   echo "pcm-pcie started at: $(timestamp)"
+  idle_wait
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -287,6 +319,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 
 if $run_maya; then
   echo "Maya profiling started at: $(timestamp)"
+  idle_wait
   maya_start=$(date +%s)
 
   # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
@@ -324,9 +357,10 @@ fi
 
 if $run_toplev_basic; then
   echo "Toplev basic profiling started at: $(timestamp)"
+  idle_wait
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
-  source /local/tools/bci_env/bin/activate
+    source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
@@ -354,6 +388,7 @@ fi
 
 if $run_toplev_execution; then
   echo "Toplev execution profiling started at: $(timestamp)"
+  idle_wait
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -381,6 +416,7 @@ fi
 
 if $run_toplev_full; then
   echo "Toplev full profiling started at: $(timestamp)"
+  idle_wait
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate


### PR DESCRIPTION
## Summary
- add `idle_wait` helper to run scripts for consistent cooldown
- invoke cooldown before PCM, Maya and Toplev commands across run scripts

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a63f7af78832cb68fbdf63db07f36