### PR TITLE
Fix run_3 PCM timing and standardize PCM memory variables

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -183,7 +183,7 @@ fi
 
 if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
       -csv=/local/data/results/id_1_pcm_memory.csv \
@@ -191,10 +191,10 @@ if $run_pcm_memory; then
       taskset -c 6 /local/bci_code/id_1/main \
     >>/local/data/results/id_1_pcm_memory.log 2>&1
   '
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
 fi
 

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -189,7 +189,7 @@ fi
 
 if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-memory \
       -csv=/local/data/results/id_13_pcm_memory.csv \
@@ -203,10 +203,10 @@ if $run_pcm_memory; then
           -r \"cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;\"
       "
   ' >> /local/data/results/id_13_pcm_memory.log 2>&1
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm \"$pcm_memory_runtime\")" > /local/data/results/done_pcm_memory.log
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm \"$pcm_mem_runtime\")" > /local/data/results/done_pcm_memory.log
 fi
 
 if $run_pcm_power; then

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -201,7 +201,7 @@ if $run_pcm; then
     > /local/data/results/done_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -220,10 +220,10 @@ if $run_pcm; then
           --modelPath=/local/data/speechBaseline4/
       "
   ' >>/local/data/results/id_20_pcm_memory.log 2>&1
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -193,7 +193,7 @@ if $run_pcm; then
     > /local/data/results/done_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -212,10 +212,10 @@ if $run_pcm; then
           --modelPath=/local/data/speechBaseline4/
       "
   ' >>/local/data/results/id_20_3gram_pcm_memory.log 2>&1
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -193,7 +193,7 @@ if $run_pcm; then
     > /local/data/results/done_llm_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -212,10 +212,10 @@ if $run_pcm; then
           --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
       "
   ' >>/local/data/results/id_20_3gram_llm_pcm_memory.log 2>&1
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_llm_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -193,7 +193,7 @@ if $run_pcm; then
     > /local/data/results/done_lm_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -212,10 +212,10 @@ if $run_pcm; then
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
       "
   ' >>/local/data/results/id_20_3gram_lm_pcm_memory.log 2>&1
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_lm_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -115,8 +115,8 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_memory_start=0
-pcm_memory_end=0
+pcm_mem_start=0
+pcm_mem_end=0
 pcm_power_start=0
 pcm_power_end=0
 pcm_pcie_start=0
@@ -193,7 +193,7 @@ if $run_pcm; then
     > /local/data/results/done_rnn_pcm.log
 
   echo "pcm-memory started at: $(timestamp)"
-  pcm_memory_start=$(date +%s)
+  pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -212,10 +212,10 @@ if $run_pcm; then
           --modelPath=/local/data/speechBaseline4/
       "
   ' >>/local/data/results/id_20_3gram_rnn_pcm_memory.log 2>&1
-  pcm_memory_end=$(date +%s)
+  pcm_mem_end=$(date +%s)
   echo "pcm-memory finished at: $(timestamp)"
-  pcm_memory_runtime=$((pcm_memory_end - pcm_memory_start))
-  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_memory_runtime")" \
+  pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
+  echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_rnn_pcm_memory.log
 
   echo "pcm-power started at: $(timestamp)"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -115,8 +115,6 @@ maya_start=0
 maya_end=0
 pcm_start=0
 pcm_end=0
-pcm_gen_start=0
-pcm_gen_end=0
 pcm_mem_start=0
 pcm_mem_end=0
 pcm_power_start=0
@@ -171,7 +169,6 @@ fi
 if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
-  pcm_gen_start=$(date +%s)
   sudo bash -lc '
     source /local/tools/compression_env/bin/activate
     cd /local/bci_code/id_3/code
@@ -181,9 +178,9 @@ if $run_pcm; then
       taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm.csv \
     >>/local/data/results/id_3_pcm.log 2>&1
   '
-  pcm_gen_end=$(date +%s)
+  pcm_end=$(date +%s)
   echo "pcm finished at: $(timestamp)"
-  pcm_runtime=$((pcm_gen_end - pcm_gen_start))
+  pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
 fi


### PR DESCRIPTION
## Summary
- standardize PCM memory timer variable names across run scripts
- record PCM start/stop times correctly in `run_3.sh`

## Testing
- `shellcheck scripts/run_*.sh`
- `bash -n scripts/run_*.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a72eaddf8832c9b8d3534f1a81f3d