### PR TITLE
Ensure pcm-pcie runs before other PCM tools

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -163,6 +163,23 @@ cd ~
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
+if $run_pcm_pcie; then
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
+  sudo sh -c '
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_1_pcm_pcie.csv \
+      -B 1.0 -- \
+      taskset -c 6 /local/bci_code/id_1/main \
+    >>/local/data/results/id_1_pcm_pcie.log 2>&1
+  '
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  echo "pcm-pcie runtime: $(secs_to_dhm \"$pcm_pcie_runtime\")" \
+    > /local/data/results/done_pcm_pcie.log
+fi
+
 
 if $run_pcm; then
   echo "pcm started at: $(timestamp)"
@@ -213,23 +230,6 @@ if $run_pcm_power; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
-fi
-
-if $run_pcm_pcie; then
-  echo "pcm-pcie started at: $(timestamp)"
-  pcm_pcie_start=$(date +%s)
-  sudo sh -c '
-    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
-      -csv=/local/data/results/id_1_pcm_pcie.csv \
-      -B 1.0 -- \
-      taskset -c 6 /local/bci_code/id_1/main \
-    >>/local/data/results/id_1_pcm_pcie.log 2>&1
-  '
-  pcm_pcie_end=$(date +%s)
-  echo "pcm-pcie finished at: $(timestamp)"
-  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
-  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
-    > /local/data/results/done_pcm_pcie.log
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -174,6 +174,34 @@ fi
 
 if $run_pcm; then
 
+
+
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_20_pcm_pcie.csv \
+      -B 1.0 -- \
+      bash -lc "
+        source /local/tools/bci_env/bin/activate
+        . path.sh
+        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
+        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/
+      "
+  ' >>/local/data/results/id_20_pcm_pcie.log 2>&1
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
+    > /local/data/results/done_pcm_pcie.log
+
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -251,32 +279,6 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
-
-  echo "pcm-pcie started at: $(timestamp)"
-  pcm_pcie_start=$(date +%s)
-  sudo -E bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
-      -csv=/local/data/results/id_20_pcm_pcie.csv \
-      -B 1.0 -- \
-      bash -lc "
-        source /local/tools/bci_env/bin/activate
-        . path.sh
-        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/
-      "
-  ' >>/local/data/results/id_20_pcm_pcie.log 2>&1
-  pcm_pcie_end=$(date +%s)
-  echo "pcm-pcie finished at: $(timestamp)"
-  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
-  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
-    > /local/data/results/done_pcm_pcie.log
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -166,6 +166,34 @@ fi
 
 if $run_pcm; then
 
+
+
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 6 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_20_3gram_pcm_pcie.csv \
+      -B 1.0 -- \
+      bash -lc "
+        source /local/tools/bci_env/bin/activate
+        . path.sh
+        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
+        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/
+      "
+  ' >>/local/data/results/id_20_3gram_pcm_pcie.log 2>&1
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
+    > /local/data/results/done_pcm_pcie.log
+
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -243,32 +271,6 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
-
-  echo "pcm-pcie started at: $(timestamp)"
-  pcm_pcie_start=$(date +%s)
-  sudo -E bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 6 /local/tools/pcm/build/bin/pcm-pcie \
-      -csv=/local/data/results/id_20_3gram_pcm_pcie.csv \
-      -B 1.0 -- \
-      bash -lc "
-        source /local/tools/bci_env/bin/activate
-        . path.sh
-        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/
-      "
-  ' >>/local/data/results/id_20_3gram_pcm_pcie.log 2>&1
-  pcm_pcie_end=$(date +%s)
-  echo "pcm-pcie finished at: $(timestamp)"
-  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
-  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
-    > /local/data/results/done_pcm_pcie.log
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -166,6 +166,33 @@ fi
 
 if $run_pcm; then
 
+
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 6 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_20_3gram_llm_pcm_pcie.csv \
+      -B 1.0 -- \
+      bash -lc "
+        source /local/tools/bci_env/bin/activate
+        . path.sh
+        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
+        python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
+      "
+  ' >>/local/data/results/id_20_3gram_llm_pcm_pcie.log 2>&1
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
+    > /local/data/results/done_llm_pcm_pcie.log
+
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -243,32 +270,6 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_llm_pcm_power.log
-
-  echo "pcm-pcie started at: $(timestamp)"
-  pcm_pcie_start=$(date +%s)
-  sudo -E bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 6 /local/tools/pcm/build/bin/pcm-pcie \
-      -csv=/local/data/results/id_20_3gram_llm_pcm_pcie.csv \
-      -B 1.0 -- \
-      bash -lc "
-        source /local/tools/bci_env/bin/activate
-        . path.sh
-        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-          --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-          --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
-      "
-  ' >>/local/data/results/id_20_3gram_llm_pcm_pcie.log 2>&1
-  pcm_pcie_end=$(date +%s)
-  echo "pcm-pcie finished at: $(timestamp)"
-  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
-  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
-    > /local/data/results/done_llm_pcm_pcie.log
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -166,6 +166,33 @@ fi
 
 if $run_pcm; then
 
+
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
+  sudo -E bash -lc '
+    source /local/tools/bci_env/bin/activate
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    . path.sh
+    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+
+    taskset -c 6 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_20_3gram_rnn_pcm_pcie.csv \
+      -B 1.0 -- \
+      bash -lc "
+        source /local/tools/bci_env/bin/activate
+        . path.sh
+        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
+        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+          --datasetPath=/local/data/ptDecoder_ctc \
+          --modelPath=/local/data/speechBaseline4/
+      "
+  ' >>/local/data/results/id_20_3gram_rnn_pcm_pcie.log 2>&1
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
+    > /local/data/results/done_rnn_pcm_pcie.log
+
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -243,32 +270,6 @@ if $run_pcm; then
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_rnn_pcm_power.log
-
-  echo "pcm-pcie started at: $(timestamp)"
-  pcm_pcie_start=$(date +%s)
-  sudo -E bash -lc '
-    source /local/tools/bci_env/bin/activate
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    . path.sh
-    export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
-
-    taskset -c 6 /local/tools/pcm/build/bin/pcm-pcie \
-      -csv=/local/data/results/id_20_3gram_rnn_pcm_pcie.csv \
-      -B 1.0 -- \
-      bash -lc "
-        source /local/tools/bci_env/bin/activate
-        . path.sh
-        export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-          --datasetPath=/local/data/ptDecoder_ctc \
-          --modelPath=/local/data/speechBaseline4/
-      "
-  ' >>/local/data/results/id_20_3gram_rnn_pcm_pcie.log 2>&1
-  pcm_pcie_end=$(date +%s)
-  echo "pcm-pcie finished at: $(timestamp)"
-  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
-  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
-    > /local/data/results/done_rnn_pcm_pcie.log
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -166,6 +166,25 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
 
+
+if $run_pcm_pcie; then
+  echo "pcm-pcie started at: $(timestamp)"
+  pcm_pcie_start=$(date +%s)
+  sudo bash -lc '
+    source /local/tools/compression_env/bin/activate
+    cd /local/bci_code/id_3/code
+    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
+      -csv=/local/data/results/id_3_pcm_pcie.csv \
+      -B 1.0 -- \
+      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm_pcie.csv \
+    >>/local/data/results/id_3_pcm_pcie.log 2>&1
+  '
+  pcm_pcie_end=$(date +%s)
+  echo "pcm-pcie finished at: $(timestamp)"
+  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
+  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
+    > /local/data/results/done_pcm_pcie.log
+fi
 if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -223,24 +242,6 @@ if $run_pcm_power; then
     > /local/data/results/done_pcm_power.log
 fi
 
-if $run_pcm_pcie; then
-  echo "pcm-pcie started at: $(timestamp)"
-  pcm_pcie_start=$(date +%s)
-  sudo bash -lc '
-    source /local/tools/compression_env/bin/activate
-    cd /local/bci_code/id_3/code
-    taskset -c 5 /local/tools/pcm/build/bin/pcm-pcie \
-      -csv=/local/data/results/id_3_pcm_pcie.csv \
-      -B 1.0 -- \
-      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm_pcie.csv \
-    >>/local/data/results/id_3_pcm_pcie.log 2>&1
-  '
-  pcm_pcie_end=$(date +%s)
-  echo "pcm-pcie finished at: $(timestamp)"
-  pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
-  echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
-    > /local/data/results/done_pcm_pcie.log
-fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"


### PR DESCRIPTION
## Summary
- Reorder PCM profiling so pcm-pcie executes before pcm, pcm-memory and pcm-power in every run script
- Restore executable bit for `run_1.sh`

## Testing
- `bash -n scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh`
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a7715eb9c832cad1ed926e9965d58