### PR TITLE
Separate PCM tool execution in ID-20 run scripts

### DIFF
--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -172,7 +172,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
 
-if $run_pcm; then
+if $run_pcm_pcie; then
   
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -200,6 +200,9 @@ if $run_pcm; then
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_pcm_pcie.log
 
+fi
+
+if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -226,6 +229,9 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
 
+fi
+
+if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -252,6 +258,9 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
 
+fi
+
+if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -164,7 +164,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
 
-if $run_pcm; then
+if $run_pcm_pcie; then
 
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -192,6 +192,9 @@ if $run_pcm; then
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_pcm_pcie.log
 
+fi
+
+if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -218,6 +221,9 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
 
+fi
+
+if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -244,6 +250,9 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
 
+fi
+
+if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -164,7 +164,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
 
-if $run_pcm; then
+if $run_pcm_pcie; then
 
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -192,6 +192,9 @@ if $run_pcm; then
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_llm_pcm_pcie.log
 
+fi
+
+if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -218,6 +221,9 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_llm_pcm.log
 
+fi
+
+if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -244,6 +250,9 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_llm_pcm_memory.log
 
+fi
+
+if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -164,7 +164,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
 
-if $run_pcm; then
+if $run_pcm_pcie; then
 
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -192,6 +192,9 @@ if $run_pcm; then
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_lm_pcm_pcie.log
 
+fi
+
+if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -218,6 +221,9 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_lm_pcm.log
 
+fi
+
+if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -244,6 +250,9 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_lm_pcm_memory.log
 
+fi
+
+if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -164,7 +164,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   sudo modprobe msr
 fi
 
-if $run_pcm; then
+if $run_pcm_pcie; then
 
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -192,6 +192,9 @@ if $run_pcm; then
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_rnn_pcm_pcie.log
 
+fi
+
+if $run_pcm; then
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -218,6 +221,9 @@ if $run_pcm; then
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_rnn_pcm.log
 
+fi
+
+if $run_pcm_memory; then
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -244,6 +250,9 @@ if $run_pcm; then
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_rnn_pcm_memory.log
 
+fi
+
+if $run_pcm_power; then
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '


### PR DESCRIPTION
## Summary
- allow ID-20 run scripts to invoke pcm, pcm-memory, pcm-power and pcm-pcie independently

## Testing
- `bash -n scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a7dd02ebc832c8c2c99e1daef8bd4