### PR TITLE
feat: idle before profiling tools

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -128,6 +128,37 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"
+  local SLEEP_STEP=3
+  local waited=0
+  local message="minimum sleep ${MIN_SLEEP}s elapsed"
+
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+  if [ -r "${TEMP_PATH}" ]; then
+    while :; do
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        message="temperature ${t}mc ≤ ${TEMP_TARGET_MC}mc"
+        break
+      fi
+      if [ "$waited" -ge "$MAX_WAIT" ]; then
+        message="timeout at ${waited}s; temperature ${t:-unknown}mc"
+        break
+      fi
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  else
+    message="temperature sensor unavailable"
+  fi
+  echo "Idle wait complete after ${waited}s (${message})"
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -165,6 +196,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo sh -c '
@@ -182,6 +214,7 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo sh -c '
@@ -199,6 +232,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo sh -c '
@@ -216,6 +250,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo sh -c '
@@ -247,6 +282,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
@@ -277,6 +313,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
@@ -299,6 +336,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo cset shield --exec -- sh -c '
@@ -320,6 +358,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo cset shield --exec -- sh -c '

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -128,6 +128,37 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"
+  local SLEEP_STEP=3
+  local waited=0
+  local message="minimum sleep ${MIN_SLEEP}s elapsed"
+
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+  if [ -r "${TEMP_PATH}" ]; then
+    while :; do
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        message="temperature ${t}mc ≤ ${TEMP_TARGET_MC}mc"
+        break
+      fi
+      if [ "$waited" -ge "$MAX_WAIT" ]; then
+        message="timeout at ${waited}s; temperature ${t:-unknown}mc"
+        break
+      fi
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  else
+    message="temperature sensor unavailable"
+  fi
+  echo "Idle wait complete after ${waited}s (${message})"
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -165,6 +196,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
@@ -193,6 +225,7 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -221,6 +254,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -249,6 +283,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -291,6 +326,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -317,6 +353,7 @@ if $run_maya; then
     kill "$MAYA_PID"
   '
 
+  idle_wait
   # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -338,6 +375,7 @@ if $run_maya; then
     kill "$MAYA_PID"
   '
 
+  idle_wait
   # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
@@ -370,6 +408,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
 
@@ -390,6 +429,7 @@ if $run_toplev_basic; then
         --modelPath=/local/data/speechBaseline4/
   ' &> /local/data/results/id_20_3gram_rnn_toplev_basic.log
 
+  idle_wait
   # LM script
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -407,6 +447,7 @@ if $run_toplev_basic; then
         --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
   ' &> /local/data/results/id_20_3gram_lm_toplev_basic.log
 
+  idle_wait
   # LLM script
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -436,6 +477,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -452,6 +494,7 @@ if $run_toplev_execution; then
           --modelPath=/local/data/speechBaseline4/
   ' &> /local/data/results/id_20_3gram_rnn_toplev_execution.log
 
+  idle_wait
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -466,6 +509,7 @@ if $run_toplev_execution; then
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
   ' &> /local/data/results/id_20_3gram_lm_toplev_execution.log
 
+  idle_wait
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -492,6 +536,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -508,6 +553,7 @@ if $run_toplev_full; then
           --modelPath=/local/data/speechBaseline4/
   ' &> /local/data/results/id_20_3gram_rnn_toplev.log
 
+  idle_wait
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -522,6 +568,7 @@ if $run_toplev_full; then
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
   ' &> /local/data/results/id_20_3gram_lm_toplev.log
 
+  idle_wait
   sudo -E cset shield --exec -- bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -128,6 +128,37 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"
+  local SLEEP_STEP=3
+  local waited=0
+  local message="minimum sleep ${MIN_SLEEP}s elapsed"
+
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+  if [ -r "${TEMP_PATH}" ]; then
+    while :; do
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        message="temperature ${t}mc ≤ ${TEMP_TARGET_MC}mc"
+        break
+      fi
+      if [ "$waited" -ge "$MAX_WAIT" ]; then
+        message="timeout at ${waited}s; temperature ${t:-unknown}mc"
+        break
+      fi
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  else
+    message="temperature sensor unavailable"
+  fi
+  echo "Idle wait complete after ${waited}s (${message})"
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -165,6 +196,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
@@ -193,6 +225,7 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -221,6 +254,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -249,6 +283,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -291,6 +326,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -326,6 +362,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -355,6 +392,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -382,6 +420,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  idle_wait
   echo "Toplev profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -128,6 +128,37 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"
+  local SLEEP_STEP=3
+  local waited=0
+  local message="minimum sleep ${MIN_SLEEP}s elapsed"
+
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+  if [ -r "${TEMP_PATH}" ]; then
+    while :; do
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        message="temperature ${t}mc ≤ ${TEMP_TARGET_MC}mc"
+        break
+      fi
+      if [ "$waited" -ge "$MAX_WAIT" ]; then
+        message="timeout at ${waited}s; temperature ${t:-unknown}mc"
+        break
+      fi
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  else
+    message="temperature sensor unavailable"
+  fi
+  echo "Idle wait complete after ${waited}s (${message})"
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -165,6 +196,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
@@ -193,6 +225,7 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -221,6 +254,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -249,6 +283,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -291,6 +326,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -326,6 +362,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -356,6 +393,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -383,6 +421,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  idle_wait
   echo "Toplev profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -128,6 +128,37 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"
+  local SLEEP_STEP=3
+  local waited=0
+  local message="minimum sleep ${MIN_SLEEP}s elapsed"
+
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+  if [ -r "${TEMP_PATH}" ]; then
+    while :; do
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        message="temperature ${t}mc ≤ ${TEMP_TARGET_MC}mc"
+        break
+      fi
+      if [ "$waited" -ge "$MAX_WAIT" ]; then
+        message="timeout at ${waited}s; temperature ${t:-unknown}mc"
+        break
+      fi
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  else
+    message="temperature sensor unavailable"
+  fi
+  echo "Idle wait complete after ${waited}s (${message})"
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -165,6 +196,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo -E bash -lc '
@@ -193,6 +225,7 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo -E bash -lc '
@@ -221,6 +254,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo -E bash -lc '
@@ -249,6 +283,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -291,6 +326,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
 
@@ -328,6 +364,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -358,6 +395,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -385,6 +423,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -128,6 +128,37 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+idle_wait() {
+  local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
+  local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
+  local TEMP_PATH="${IDLE_TEMP_PATH:-/sys/class/thermal/thermal_zone0/temp}"
+  local MAX_WAIT="${IDLE_MAX_WAIT:-600}"
+  local SLEEP_STEP=3
+  local waited=0
+  local message="minimum sleep ${MIN_SLEEP}s elapsed"
+
+  sleep "${MIN_SLEEP}"
+  waited=$((waited+MIN_SLEEP))
+  if [ -r "${TEMP_PATH}" ]; then
+    while :; do
+      t=$(cat "${TEMP_PATH}" 2>/dev/null || echo "")
+      if [ -n "$t" ] && [ "$t" -le "$TEMP_TARGET_MC" ]; then
+        message="temperature ${t}mc ≤ ${TEMP_TARGET_MC}mc"
+        break
+      fi
+      if [ "$waited" -ge "$MAX_WAIT" ]; then
+        message="timeout at ${waited}s; temperature ${t:-unknown}mc"
+        break
+      fi
+      sleep "$SLEEP_STEP"
+      waited=$((waited+SLEEP_STEP))
+    done
+  else
+    message="temperature sensor unavailable"
+  fi
+  echo "Idle wait complete after ${waited}s (${message})"
+}
+
 ################################################################################
 ### 1. Create results directory (if it doesn't exist already)
 ################################################################################
@@ -167,6 +198,7 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
   sudo bash -lc '
@@ -186,6 +218,7 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
   sudo bash -lc '
@@ -205,6 +238,7 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
   sudo bash -lc '
@@ -224,6 +258,7 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo bash -lc '
@@ -257,6 +292,7 @@ sudo cset shield --cpu 5,6,15,16 --kthread=on
 ################################################################################
 
 if $run_maya; then
+  idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -287,6 +323,7 @@ fi
 ################################################################################
 
 if $run_toplev_basic; then
+  idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -311,6 +348,7 @@ fi
 ################################################################################
 
 if $run_toplev_execution; then
+  idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
@@ -333,6 +371,7 @@ fi
 ################################################################################
 
 if $run_toplev_full; then
+  idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
 


### PR DESCRIPTION
## Summary
- add `idle_wait` helper to run scripts to pause until cool or timeout
- invoke `idle_wait` before each profiler tool run to log reason for waiting

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a82f1f038832cbcf2a8fa68c6e01e