### PR TITLE
Add power and frequency verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,6 @@ separate from profiler outputs like `id_3_pcm.csv` or
 `results/`.
 CSV helpers in `id_3/code/utils.py` automatically return an empty DataFrame when
 the file is missing or empty so repeated runs start with a clean slate.
+
+Run scripts now print the applied turbo state, RAPL power limits and frequency
+settings after configuration to help verify the environment before execution.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the proper directory
 ################################################################################
 cd ~

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the BCI project directory
 ################################################################################
 cd ~

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -227,6 +227,54 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
+### Verify power/turbo/frequency settings
+################################################################################
+# Ensure CPU_LIST exists (fallback recompute from this script)
+if [ -z "${CPU_LIST:-}" ]; then
+  SCRIPT_FILE="$(readlink -f "$0")"
+  CPU_LIST_RAW="$(
+    { grep -Eo 'taskset -c[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $3}';
+      grep -Eo 'cset shield --cpu[[:space:]]+[0-9,]+' "$SCRIPT_FILE" | awk '{print $4}'; } 2>/dev/null
+  )"
+  CPU_LIST="$(echo "$CPU_LIST_RAW" | tr ',' '\n' | grep -E '^[0-9]+$' | sort -n | uniq | paste -sd, -)"
+  [ -z "$CPU_LIST" ] && CPU_LIST="0"
+fi
+
+# Turbo state
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+  echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
+fi
+if [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+  echo "cpufreq.boost        = $(cat /sys/devices/system/cpu/cpufreq/boost) (0=disabled)"
+fi
+
+# RAPL package/DRAM caps
+DOM=/sys/class/powercap/intel-rapl:0
+if [ -r "$DOM/constraint_0_power_limit_uw" ]; then
+  pkg_uw=$(cat "$DOM/constraint_0_power_limit_uw")
+  printf "RAPL PKG limit       = %.3f W\n" "$(awk -v x="$pkg_uw" 'BEGIN{print x/1000000}')"
+fi
+if [ -r "$DOM/constraint_0_time_window_us" ]; then
+  echo "RAPL PKG window (us) = $(cat "$DOM/constraint_0_time_window_us")"
+fi
+DRAM=/sys/class/powercap/intel-rapl:0:0
+if [ -r "$DRAM/constraint_0_power_limit_uw" ]; then
+  dram_uw=$(cat "$DRAM/constraint_0_power_limit_uw")
+  printf "RAPL DRAM limit      = %.3f W\n" "$(awk -v x="$dram_uw" 'BEGIN{print x/1000000}')"
+fi
+
+# Frequency pinning status for all CPUs used in this script
+for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
+  base="/sys/devices/system/cpu/cpu$cpu/cpufreq"
+  if [ -d "$base" ]; then
+    gov=$(cat "$base/scaling_governor" 2>/dev/null || echo "?")
+    fmin=$(cat "$base/scaling_min_freq" 2>/dev/null || echo "?")
+    fmax=$(cat "$base/scaling_max_freq" 2>/dev/null || echo "?")
+    echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
+  fi
+done
+
+################################################################################
 ### 2. Change into the ID-3 code directory
 ################################################################################
 cd /local/bci_code/id_3/code


### PR DESCRIPTION
## Summary
- print applied turbo settings, RAPL power caps, and cpufreq pinning across run scripts
- document new environment verification in AGENTS guide

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b5315ceb0832c8641820505d19f69