### PR TITLE
Organize run scripts with initialization and power steps

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-1 (Seizure Detection – Laelaps)"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_pcm_
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,12 +280,12 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the proper directory
+### 3. Change into the proper directory
 ################################################################################
 cd ~
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -364,13 +369,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -401,7 +406,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -424,7 +429,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -446,7 +451,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -468,7 +473,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -484,13 +489,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-13 (Movement Intent)"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_pcm_
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,12 +280,12 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the home directory
+### 3. Change into the home directory
 ################################################################################
 cd ~
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -384,13 +389,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -422,7 +427,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -451,7 +456,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -478,7 +483,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -505,7 +510,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -515,13 +520,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-20 3gram"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_pcm_
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,12 +280,12 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the BCI project directory
+### 3. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -408,13 +413,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -496,7 +501,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -565,7 +570,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -624,7 +629,7 @@ fi
 
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -682,7 +687,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -703,14 +708,14 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-20 3gram LLM"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_llm_
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_llm_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_llm_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,12 +280,12 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the BCI project directory
+### 3. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -408,13 +413,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -450,7 +455,7 @@ echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -480,7 +485,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -508,7 +513,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -536,7 +541,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -547,13 +552,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-20 3gram LM"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_lm_p
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_lm_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_lm_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,12 +280,12 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the BCI project directory
+### 3. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -408,13 +413,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -450,7 +455,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -481,7 +486,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -509,7 +514,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -536,7 +541,7 @@ if $run_toplev_full; then
     > /local/data/results/done_lm_toplev_full.log
 fi
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -547,13 +552,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-20 3gram RNN"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_rnn_
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_rnn_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_rnn_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,12 +280,12 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the BCI project directory
+### 3. Change into the BCI project directory
 ################################################################################
 cd /local/tools/bci_project
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -408,13 +413,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -452,7 +457,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -483,7 +488,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -511,7 +516,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -540,7 +545,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -551,13 +556,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# If the script is launched outside a tmux session, re-run it inside tmux so
-# that it keeps running even if the SSH connection drops.
+################################################################################
+### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
+################################################################################
+
+# Start tmux session if running outside tmux
 if [[ -z ${TMUX:-} ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
@@ -10,12 +13,11 @@ if [[ -z ${TMUX:-} ]]; then
   exec tmux new-session -s "$session_name" "$script_path" "$@"
 fi
 
-# Log to /local/logs/run.log
+# Create unified log file
 mkdir -p /local/logs
 exec > >(tee -a /local/logs/run.log) 2>&1
 
-
-# Parse tool selection arguments inside tmux
+# Parse tool selection arguments
 run_toplev_basic=false
 run_toplev_full=false
 run_toplev_execution=false
@@ -77,7 +79,7 @@ if ! $run_toplev_basic && ! $run_toplev_full && ! $run_toplev_execution && \
   run_pcm_pcie=true
 fi
 
-# Describe this workload
+# Describe this workload for logging
 workload_desc="ID-3 (Compression)"
 
 # Announce planned run and provide 10s window to cancel
@@ -97,6 +99,7 @@ for i in {10..1}; do
   sleep 1
 done
 
+# Record experiment start time
 echo "Experiment started at: $(TZ=America/Toronto date '+%Y-%m-%d - %H:%M')"
 
 # Helper for consistent timestamps
@@ -128,6 +131,7 @@ secs_to_dhm() {
   printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
 }
 
+# Wait for system to cool/idle before each run
 idle_wait() {
   local MIN_SLEEP="${IDLE_MIN_SLEEP:-45}"
   local TEMP_TARGET_MC="${IDLE_TEMP_TARGET_MC:-50000}"
@@ -160,7 +164,7 @@ idle_wait() {
 }
 
 ################################################################################
-### 1. Create results directory (if it doesn't exist already)
+### 1. Create results directory and placeholder logs
 ################################################################################
 cd /local; mkdir -p data/results
 # Determine permissions target based on original invoking user
@@ -182,7 +186,10 @@ $run_pcm_memory || echo "PCM-memory run skipped" > /local/data/results/done_pcm_
 $run_pcm_power || echo "PCM-power run skipped" > /local/data/results/done_pcm_power.log
 $run_pcm_pcie || echo "PCM-pcie run skipped" > /local/data/results/done_pcm_pcie.log
 
-# --- Power controls (configurable via env), do not change CPU IDs ---
+################################################################################
+### 2. Configure and verify power settings
+################################################################################
+# Load msr module to allow power management commands
 sudo modprobe msr || true
 
 # Disable turbo (try both interfaces; ignore failures)
@@ -226,9 +233,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
   fi
 done
 
-################################################################################
-### Verify power/turbo/frequency settings
-################################################################################
+# Display resulting power, turbo, and frequency settings
 # Ensure CPU_LIST exists (fallback recompute from this script)
 if [ -z "${CPU_LIST:-}" ]; then
   SCRIPT_FILE="$(readlink -f "$0")"
@@ -275,14 +280,14 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
 done
 
 ################################################################################
-### 2. Change into the ID-3 code directory
+### 3. Change into the ID-3 code directory
 ################################################################################
 cd /local/bci_code/id_3/code
 
 source /local/tools/compression_env/bin/activate
 
 ################################################################################
-### 3. PCM profiling
+### 4. PCM profiling
 ################################################################################
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -374,13 +379,13 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 ################################################################################
-### 4. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
+### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 5. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -411,7 +416,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 6. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -436,7 +441,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 7. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -459,7 +464,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 8. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -483,7 +488,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 9. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -494,13 +499,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 10. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 11. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {


### PR DESCRIPTION
## Summary
- add Step 0 section to run scripts for tmux setup, logging, CLI parsing and helpers
- rename Step 1 to include placeholder logs and introduce Step 2 for power controls with verification
- renumber subsequent steps across all run scripts for clarity

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b5e6ca4b0832cb53b082a31b17670