### PR TITLE
Offline non-essential CPUs during profiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,5 @@ the file is missing or empty so repeated runs start with a clean slate.
 
 Run scripts now print the applied turbo state, RAPL power limits and frequency
 settings after configuration to help verify the environment before execution.
+Before Maya or Toplev profiling, they offline all CPUs except 0,5,6 and disable
+SMT, restoring the original CPU state once profiling completes.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -375,7 +375,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -406,7 +434,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -429,7 +457,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -451,7 +479,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -473,7 +501,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -489,13 +517,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"
@@ -523,3 +551,17 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_memory.log \
       /local/data/results/done_pcm_power.log \
       /local/data/results/done_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -395,7 +395,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -427,7 +455,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -456,7 +484,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -483,7 +511,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -510,7 +538,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -520,13 +548,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
@@ -555,3 +583,17 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_memory.log \
       /local/data/results/done_pcm_power.log \
       /local/data/results/done_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -427,7 +427,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -493,7 +521,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -547,7 +575,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -595,7 +623,7 @@ fi
 ################################################################################
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -641,7 +669,7 @@ if $run_toplev_full; then
     > /local/data/results/done_toplev_full.log
 fi
 ################################################################################
-### 10. Convert Maya raw output to CSV
+### 11. Convert Maya raw output to CSV
 ################################################################################
 
 if $run_maya; then
@@ -666,14 +694,14 @@ fi
 
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
@@ -702,3 +730,17 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_memory.log \
       /local/data/results/done_pcm_power.log \
       /local/data/results/done_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -419,7 +419,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -501,7 +529,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -570,7 +598,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -629,7 +657,7 @@ fi
 
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -687,7 +715,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -708,14 +736,14 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
@@ -744,3 +772,17 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_memory.log \
       /local/data/results/done_pcm_power.log \
       /local/data/results/done_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -419,7 +419,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -455,7 +483,7 @@ echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -485,7 +513,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -513,7 +541,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -541,7 +569,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -552,13 +580,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
@@ -587,3 +615,17 @@ rm -f /local/data/results/done_llm_toplev_basic.log \
       /local/data/results/done_llm_pcm_memory.log \
       /local/data/results/done_llm_pcm_power.log \
       /local/data/results/done_llm_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -419,7 +419,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -457,7 +485,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -488,7 +516,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -516,7 +544,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -545,7 +573,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -556,13 +584,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"
@@ -590,3 +618,17 @@ rm -f /local/data/results/done_rnn_toplev_basic.log \
       /local/data/results/done_rnn_pcm_memory.log \
       /local/data/results/done_rnn_pcm_power.log \
       /local/data/results/done_rnn_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -385,7 +385,35 @@ fi
 sudo cset shield --cpu 5,6 --kthread=on
 
 ################################################################################
-### 6. Maya profiling
+### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
+################################################################################
+KEEP_CPUS="0,5,6"
+
+echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# Prefer global SMT control if available
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+
+# Offline all CPUs not in KEEP_CPUS
+keep_set=",$KEEP_CPUS,"
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  case "$keep_set" in
+    *,"$cpu",*) ;;  # keep
+    *)
+      if [ -w "$cpu_dir/online" ]; then
+        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
+      fi
+      ;;
+  esac
+done
+
+echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+
+################################################################################
+### 7. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -416,7 +444,7 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 7. Toplev basic profiling
+### 8. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -441,7 +469,7 @@ if $run_toplev_basic; then
 fi
 
 ################################################################################
-### 8. Toplev execution profiling
+### 9. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -464,7 +492,7 @@ if $run_toplev_execution; then
 fi
 
 ################################################################################
-### 9. Toplev full profiling
+### 10. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -488,7 +516,7 @@ if $run_toplev_full; then
 fi
 
 ################################################################################
-### 10. Convert Maya raw output files into CSV
+### 11. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -499,13 +527,13 @@ if $run_maya; then
 fi
 
 ################################################################################
-### 11. Signal completion for tmux monitoring
+### 12. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 12. Write completion file with runtimes
+### 13. Write completion file with runtimes
 ################################################################################
 
 {
@@ -534,3 +562,17 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_memory.log \
       /local/data/results/done_pcm_power.log \
       /local/data/results/done_pcm_pcie.log
+
+################################################################################
+### 14. Restore CPUs and SMT
+################################################################################
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  cpu=${cpu_dir##*/cpu}
+  if [ -w "$cpu_dir/online" ]; then
+    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
+  fi
+done
+if [ -w /sys/devices/system/cpu/smt/control ]; then
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+fi
+echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"


### PR DESCRIPTION
## Summary
- offline all CPUs except 0,5,6 before Maya or Toplev runs, disabling SMT
- restore original CPU and SMT state after profiling completes
- document CPU offlining behaviour in AGENTS guidelines

## Testing
- `bash -n scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_rnn.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b650a3428832cb2f6c339993adbe0