### PR TITLE
Remove -A flag from Toplev invocations

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -444,7 +444,7 @@ if $run_toplev_basic; then
   sudo -E cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      -A --per-thread --columns \
+      --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_1_toplev_basic.csv -- \
         taskset -c 6 /local/bci_code/id_1/main \

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -469,7 +469,7 @@ if $run_toplev_basic; then
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      -A --per-thread --columns \
+      --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_13_toplev_basic.csv -- \
         taskset -c 6 /local/tools/matlab/bin/matlab \

--- a/scripts/run_20.sh
+++ b/scripts/run_20.sh
@@ -533,7 +533,7 @@ if $run_toplev_basic; then
   sudo -E cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      -A --per-thread --columns \
+      --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_20_rnn_toplev_basic.csv -- \
         taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
@@ -547,7 +547,7 @@ if $run_toplev_basic; then
   sudo -E cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      -A --per-thread --columns \
+      --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_20_lm_toplev_basic.csv -- \
         taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
@@ -560,7 +560,7 @@ if $run_toplev_basic; then
   sudo -E cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      -A --per-thread --columns \
+      --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_20_llm_toplev_basic.csv -- \
         taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \

--- a/scripts/run_20_3gram.sh
+++ b/scripts/run_20_3gram.sh
@@ -546,7 +546,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    -A --per-thread --columns \
+    --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_rnn_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
@@ -564,7 +564,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    -A --per-thread --columns \
+    --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_lm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
@@ -582,7 +582,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    -A --per-thread --columns \
+    --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -498,7 +498,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    -A --per-thread --columns \
+    --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -498,7 +498,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    -A --per-thread --columns \
+    --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_lm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -500,7 +500,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    -A --per-thread --columns \
+    --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_rnn_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -456,7 +456,7 @@ if $run_toplev_basic; then
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      -A --per-thread --columns \
+      --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_3_toplev_basic.csv -- \
         taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_toplev_basic.csv


### PR DESCRIPTION
## Summary
- drop -A flag from all Toplev profiling calls now that CPU affinity is enforced

## Testing
- `shellcheck --severity=error scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20.sh scripts/run_20_3gram.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b679fc638832cb8d09bd2ac58a2e1