### PR TITLE
Add segment titles and blank lines to run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -161,6 +161,7 @@ idle_wait() {
     message="temperature sensor unavailable"
   fi
   echo "Idle wait complete after ${waited}s (${message})"
+  echo
 }
 
 ################################################################################
@@ -245,6 +246,9 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo "Power and frequency settings"
+echo "----------------------------"
+
 # Turbo state
 if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
   echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
@@ -278,6 +282,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
     echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
   fi
 done
+echo
 
 ################################################################################
 ### 3. Change into the proper directory
@@ -367,16 +372,22 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
+echo
 
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo "CPU shielding"
+echo "-------------"
 sudo cset shield --cpu 5,6 --kthread=on
+echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "CPU offlining"
+echo "-------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
@@ -401,6 +412,7 @@ for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
 done
 
 echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+echo
 
 ################################################################################
 ### 7. Maya profiling
@@ -432,6 +444,7 @@ if $run_maya; then
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
+echo
 
 ################################################################################
 ### 8. Toplev basic profiling
@@ -455,6 +468,7 @@ if $run_toplev_basic; then
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_toplev_basic.log
 fi
+echo
 
 ################################################################################
 ### 9. Toplev execution profiling
@@ -477,6 +491,7 @@ if $run_toplev_execution; then
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
 fi
+echo
 
 ################################################################################
 ### 10. Toplev full profiling
@@ -499,6 +514,7 @@ if $run_toplev_full; then
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_toplev_full.log
 fi
+echo
 
 ################################################################################
 ### 11. Convert Maya raw output files into CSV
@@ -515,6 +531,7 @@ if $run_maya; then
   }
   ' /local/data/results/id_1_maya.txt > /local/data/results/id_1_maya.csv
 fi
+echo
 
 ################################################################################
 ### 12. Signal completion for tmux monitoring

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -161,6 +161,7 @@ idle_wait() {
     message="temperature sensor unavailable"
   fi
   echo "Idle wait complete after ${waited}s (${message})"
+  echo
 }
 
 ################################################################################
@@ -245,6 +246,9 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo "Power and frequency settings"
+echo "----------------------------"
+
 # Turbo state
 if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
   echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
@@ -278,6 +282,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
     echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
   fi
 done
+echo
 
 ################################################################################
 ### 3. Change into the home directory
@@ -387,16 +392,22 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
+echo
 
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo "CPU shielding"
+echo "-------------"
 sudo cset shield --cpu 5,6 --kthread=on
+echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "CPU offlining"
+echo "-------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
@@ -421,6 +432,7 @@ for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
 done
 
 echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+echo
 
 ################################################################################
 ### 7. Maya profiling
@@ -453,6 +465,7 @@ if $run_maya; then
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
+echo
 
 ################################################################################
 ### 8. Toplev basic profiling
@@ -482,6 +495,7 @@ if $run_toplev_basic; then
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_toplev_basic.log
 fi
+echo
 
 ################################################################################
 ### 9. Toplev execution profiling
@@ -509,6 +523,7 @@ if $run_toplev_execution; then
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
 fi
+echo
 
 ################################################################################
 ### 10. Toplev full profiling
@@ -536,6 +551,7 @@ if $run_toplev_full; then
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_toplev_full.log
 fi
+echo
 
 ################################################################################
 ### 11. Convert Maya raw output files into CSV
@@ -546,6 +562,7 @@ if $run_maya; then
   awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?"," : "") } print "" }' \
     /local/data/results/id_13_maya.txt > /local/data/results/id_13_maya.csv
 fi
+echo
 
 ################################################################################
 ### 12. Signal completion for tmux monitoring

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -161,6 +161,7 @@ idle_wait() {
     message="temperature sensor unavailable"
   fi
   echo "Idle wait complete after ${waited}s (${message})"
+  echo
 }
 
 ################################################################################
@@ -245,6 +246,9 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo "Power and frequency settings"
+echo "----------------------------"
+
 # Turbo state
 if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
   echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
@@ -278,6 +282,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
     echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
   fi
 done
+echo
 
 ################################################################################
 ### 3. Change into the BCI project directory
@@ -411,16 +416,22 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
+echo
 
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo "CPU shielding"
+echo "-------------"
 sudo cset shield --cpu 5,6 --kthread=on
+echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "CPU offlining"
+echo "-------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
@@ -445,6 +456,7 @@ for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
 done
 
 echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+echo
 
 ################################################################################
 ### 7. Maya profiling
@@ -478,9 +490,10 @@ if $run_maya; then
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-  > /local/data/results/done_llm_maya.log
+  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
+    > /local/data/results/done_llm_maya.log
 fi
+echo
 
 ################################################################################
 ### 8. Toplev basic profiling
@@ -511,6 +524,7 @@ if $run_toplev_basic; then
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_llm_toplev_basic.log
 fi
+echo
 
 ################################################################################
 ### 9. Toplev execution profiling
@@ -539,6 +553,7 @@ if $run_toplev_execution; then
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_llm_toplev_execution.log
 fi
+echo
 
 ################################################################################
 ### 10. Toplev full profiling
@@ -546,7 +561,7 @@ fi
 
 if $run_toplev_full; then
   idle_wait
-  echo "Toplev profiling started at: $(timestamp)"
+  echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
   source /local/tools/bci_env/bin/activate
@@ -567,6 +582,7 @@ if $run_toplev_full; then
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_llm_toplev_full.log
 fi
+echo
 
 ################################################################################
 ### 11. Convert Maya raw output files into CSV
@@ -578,6 +594,7 @@ if $run_maya; then
     /local/data/results/id_20_3gram_llm_maya.txt \
     > /local/data/results/id_20_3gram_llm_maya.csv
 fi
+echo
 
 ################################################################################
 ### 12. Signal completion for tmux monitoring

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -161,6 +161,7 @@ idle_wait() {
     message="temperature sensor unavailable"
   fi
   echo "Idle wait complete after ${waited}s (${message})"
+  echo
 }
 
 ################################################################################
@@ -245,6 +246,9 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo "Power and frequency settings"
+echo "----------------------------"
+
 # Turbo state
 if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
   echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
@@ -278,6 +282,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
     echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
   fi
 done
+echo
 
 ################################################################################
 ### 3. Change into the BCI project directory
@@ -411,16 +416,22 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
+echo
 
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo "CPU shielding"
+echo "-------------"
 sudo cset shield --cpu 5,6 --kthread=on
+echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "CPU offlining"
+echo "-------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
@@ -445,6 +456,7 @@ for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
 done
 
 echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+echo
 
 ################################################################################
 ### 7. Maya profiling
@@ -483,6 +495,7 @@ if $run_maya; then
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_rnn_maya.log
 fi
+echo
 
 ################################################################################
 ### 8. Toplev basic profiling
@@ -514,6 +527,7 @@ if $run_toplev_basic; then
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_rnn_toplev_basic.log
 fi
+echo
 
 ################################################################################
 ### 9. Toplev execution profiling
@@ -542,6 +556,7 @@ if $run_toplev_execution; then
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_rnn_toplev_execution.log
 fi
+echo
 
 ################################################################################
 ### 10. Toplev full profiling
@@ -571,6 +586,7 @@ if $run_toplev_full; then
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_rnn_toplev_full.log
 fi
+echo
 
 ################################################################################
 ### 11. Convert Maya raw output files into CSV
@@ -582,6 +598,7 @@ if $run_maya; then
     /local/data/results/id_20_3gram_rnn_maya.txt \
     > /local/data/results/id_20_3gram_rnn_maya.csv
 fi
+echo
 
 ################################################################################
 ### 12. Signal completion for tmux monitoring

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -161,6 +161,7 @@ idle_wait() {
     message="temperature sensor unavailable"
   fi
   echo "Idle wait complete after ${waited}s (${message})"
+  echo
 }
 
 ################################################################################
@@ -245,6 +246,9 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo "Power and frequency settings"
+echo "----------------------------"
+
 # Turbo state
 if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
   echo "intel_pstate.no_turbo = $(cat /sys/devices/system/cpu/intel_pstate/no_turbo) (1=disabled)"
@@ -278,6 +282,7 @@ for cpu in $(echo "$CPU_LIST" | tr ',' ' '); do
     echo "cpu$cpu: governor=$gov min_khz=$fmin max_khz=$fmax"
   fi
 done
+echo
 
 ################################################################################
 ### 3. Change into the ID-3 code directory
@@ -377,16 +382,22 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
+echo
 
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo "CPU shielding"
+echo "-------------"
 sudo cset shield --cpu 5,6 --kthread=on
+echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "CPU offlining"
+echo "-------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
@@ -411,6 +422,7 @@ for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
 done
 
 echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
+echo
 
 ################################################################################
 ### 7. Maya profiling
@@ -442,6 +454,7 @@ if $run_maya; then
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > /local/data/results/done_maya.log
 fi
+echo
 
 ################################################################################
 ### 8. Toplev basic profiling
@@ -467,6 +480,7 @@ if $run_toplev_basic; then
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_toplev_basic.log
 fi
+echo
 
 ################################################################################
 ### 9. Toplev execution profiling
@@ -490,6 +504,7 @@ if $run_toplev_execution; then
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
 fi
+echo
 
 ################################################################################
 ### 10. Toplev full profiling
@@ -514,6 +529,7 @@ if $run_toplev_full; then
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_toplev_full.log
 fi
+echo
 
 ################################################################################
 ### 11. Convert Maya raw output files into CSV
@@ -525,6 +541,7 @@ if $run_maya; then
     /local/data/results/id_3_maya.txt \
     > /local/data/results/id_3_maya.csv
 fi
+echo
 
 ################################################################################
 ### 12. Signal completion for tmux monitoring


### PR DESCRIPTION
## Summary
- Group power and frequency configuration output under a "Power and frequency settings" heading
- Announce CPU shielding and offlining stages with clear titles
- Insert blank lines between profiling stages for readability across all run scripts

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b8f53bbcc832c8c99b711c82f7170