### PR TITLE
Align Maya conversion log message with other run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -521,7 +521,7 @@ echo
 ################################################################################
 
 if $run_maya; then
-  echo "Converting Maya output to CSV → /local/data/results/id_1_maya.csv"
+  echo "Converting id_1_maya.txt → id_1_maya.csv"
   awk '
   {
     for (i = 1; i <= NF; i++) {


### PR DESCRIPTION
## Summary
- Align Maya conversion log message in run_1.sh with the format used by other run scripts

## Testing
- `bash -n scripts/run_1.sh`
- `shellcheck scripts/run_1.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b95d69e3c832c8a3d48ebbae923bc