### PR TITLE
Add extraction failure messaging across startup scripts

### DIFF
--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -375,7 +375,12 @@ cd tools
 # Download Fieldtrip
 curl -L "https://drive.usercontent.google.com/download?id={1KVb_tsA1KzC7AhaZUKvR0wuR9Ob9bTJe}&confirm=xxx" -o fieldtrip-20240916.zip
 # Unzip Fieldtrip
-unzip fieldtrip-20240916.zip -d fieldtrip/
+echo "Extracting fieldtrip-20240916.zip"
+if unzip "fieldtrip-20240916.zip" -d fieldtrip/; then
+  rm "fieldtrip-20240916.zip"
+else
+  echo "Extraction failed, archive not removed."
+fi
 
 # Create directories
 cd /local/data;

--- a/scripts/startup_20.sh
+++ b/scripts/startup_20.sh
@@ -268,7 +268,11 @@ else
 fi
 # Always extract languageModel.tar.gz
 echo "Extracting languageModel.tar.gz"
-tar -xvf languageModel.tar.gz
+if tar -xvf "languageModel.tar.gz"; then
+  rm "languageModel.tar.gz"
+else
+  echo "Extraction failed, archive not removed."
+fi
 
 # Process languageModel_5gram.tar.gz (5-gram model)
 if [ -f "${PROJECT_DATA}/languageModel_5gram.tar.gz" ]; then
@@ -281,7 +285,11 @@ else
 fi
 # Always extract languageModel_5gram.tar.gz
 echo "Extracting languageModel_5gram.tar.gz"
-tar -xvf languageModel_5gram.tar.gz
+if tar -xvf "languageModel_5gram.tar.gz"; then
+  rm "languageModel_5gram.tar.gz"
+else
+  echo "Extraction failed, archive not removed."
+fi
 
 # Process ptDecoder_ctc file
 if [ -f "${PROJECT_DATA}/ptDecoder_ctc" ]; then
@@ -291,7 +299,11 @@ else
     echo "ptDecoder_ctc not found as a file. Downloading zip from Google Drive..."
     gdown https://drive.google.com/uc?id=1931UPY6hrK3ipHxDJLdn4x_6vjqMq_iA -O ptDecoder_ctc.zip
     echo "Extracting ptDecoder_ctc.zip"
-    unzip ptDecoder_ctc.zip
+    if unzip "ptDecoder_ctc.zip"; then
+      rm "ptDecoder_ctc.zip"
+    else
+      echo "Extraction failed, archive not removed."
+    fi
 fi
 
 # Process speechBaseline4 directory
@@ -302,7 +314,11 @@ else
     echo "speechBaseline4 not found as a directory. Downloading zip from Google Drive..."
     gdown https://drive.google.com/uc?id=1VajRoWKkOCmgTDDzlALsTnTzf77V7Pq7
     echo "Extracting speechBaseline4.zip"
-    unzip speechBaseline4.zip
+    if unzip "speechBaseline4.zip"; then
+      rm "speechBaseline4.zip"
+    else
+      echo "Extraction failed, archive not removed."
+    fi
 fi
 
 ################################################################################

--- a/scripts/startup_20_3gram.sh
+++ b/scripts/startup_20_3gram.sh
@@ -268,9 +268,8 @@ else
 fi
 # Always extract languageModel.tar.gz
 echo "Extracting languageModel.tar.gz"
-tar -xvf languageModel.tar.gz
-if [ $? -eq 0 ]; then
-  rm languageModel.tar.gz
+if tar -xvf "languageModel.tar.gz"; then
+  rm "languageModel.tar.gz"
 else
   echo "Extraction failed, archive not removed."
 fi
@@ -283,7 +282,11 @@ else
     echo "ptDecoder_ctc not found as a file. Downloading zip from Google Drive..."
     gdown https://drive.google.com/uc?id=1931UPY6hrK3ipHxDJLdn4x_6vjqMq_iA -O ptDecoder_ctc.zip
     echo "Extracting ptDecoder_ctc.zip"
-    unzip ptDecoder_ctc.zip
+    if unzip "ptDecoder_ctc.zip"; then
+      rm "ptDecoder_ctc.zip"
+    else
+      echo "Extraction failed, archive not removed."
+    fi
 fi
 
 # Process speechBaseline4 directory
@@ -294,7 +297,11 @@ else
     echo "speechBaseline4 not found as a directory. Downloading zip from Google Drive..."
     gdown https://drive.google.com/uc?id=1VajRoWKkOCmgTDDzlALsTnTzf77V7Pq7
     echo "Extracting speechBaseline4.zip"
-    unzip speechBaseline4.zip
+    if unzip "speechBaseline4.zip"; then
+      rm "speechBaseline4.zip"
+    else
+      echo "Extraction failed, archive not removed."
+    fi
 fi
 
 ################################################################################

--- a/scripts/startup_20_5gram.sh
+++ b/scripts/startup_20_5gram.sh
@@ -268,9 +268,8 @@ else
 fi
 # Always extract languageModel_5gram.tar.gz
 echo "Extracting languageModel_5gram.tar.gz"
-tar -xvf languageModel_5gram.tar.gz
-if [ $? -eq 0 ]; then
-  rm languageModel_5gram.tar.gz
+if tar -xvf "languageModel_5gram.tar.gz"; then
+  rm "languageModel_5gram.tar.gz"
 else
   echo "Extraction failed, archive not removed."
 fi
@@ -283,7 +282,11 @@ else
     echo "ptDecoder_ctc not found as a file. Downloading zip from Google Drive..."
     gdown https://drive.google.com/uc?id=1931UPY6hrK3ipHxDJLdn4x_6vjqMq_iA -O ptDecoder_ctc.zip
     echo "Extracting ptDecoder_ctc.zip"
-    unzip ptDecoder_ctc.zip
+    if unzip "ptDecoder_ctc.zip"; then
+      rm "ptDecoder_ctc.zip"
+    else
+      echo "Extraction failed, archive not removed."
+    fi
 fi
 
 # Process speechBaseline4 directory
@@ -294,7 +297,11 @@ else
     echo "speechBaseline4 not found as a directory. Downloading zip from Google Drive..."
     gdown https://drive.google.com/uc?id=1VajRoWKkOCmgTDDzlALsTnTzf77V7Pq7
     echo "Extracting speechBaseline4.zip"
-    unzip speechBaseline4.zip
+    if unzip "speechBaseline4.zip"; then
+      rm "speechBaseline4.zip"
+    else
+      echo "Extraction failed, archive not removed."
+    fi
 fi
 
 ################################################################################

--- a/scripts/startup_3.sh
+++ b/scripts/startup_3.sh
@@ -203,7 +203,12 @@ sudo chown -R $USER /local/data
 #### Installing AWS CLI
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
+echo "Extracting awscliv2.zip"
+if unzip "awscliv2.zip"; then
+  rm "awscliv2.zip"
+else
+  echo "Extraction failed, archive not removed."
+fi
 sudo ./aws/install
 
 mkdir -p /local/data/ephys-compression-benchmark/aind-np1


### PR DESCRIPTION
## Summary
- quote archive names in extraction blocks for consistent cleanup
- maintain extraction failure notifications across all startup scripts

## Testing
- `bash -n scripts/startup_3.sh scripts/startup_13.sh scripts/startup_20.sh scripts/startup_20_3gram.sh scripts/startup_20_5gram.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b9a3a5c1c832caeb23b5a1e861ab8