### PR TITLE
fix: robust Maya teardown across workloads

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -422,21 +422,32 @@ if $run_maya; then
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
-  sudo -E cset shield --exec -- sh -c '
-    # Start Maya on core 5 in background, log raw output
+  sudo -E cset shield --exec -- bash -lc '
+    set -euo pipefail
+
+    # Start Maya on CPU 5 in background; capture PID immediately
     taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
       > /local/data/results/id_1_maya.txt 2>&1 &
+    MAYA_PID=$!
 
-    # Give Maya a moment to start and then grab its PID
+    # Small startup delay to avoid cold-start hiccups
     sleep 1
-    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-    # Run the same workload on core 6, log its output
-    taskset -c 6 /local/bci_code/id_1/main \
-      >> /local/data/results/id_1_maya.log 2>&1
+    # Verify placement (non-fatal)
+    ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
 
-    # After workload exits, terminate Maya
-    kill "$MAYA_PID"
+    # Run workload on CPU 6
+    taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1 || true
+
+    # Idempotent teardown with escalation and reap
+    for sig in TERM KILL; do
+      if kill -0 "$MAYA_PID" 2>/dev/null; then
+        kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+        timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+      fi
+      kill -0 "$MAYA_PID" 2>/dev/null || break
+    done
+    wait "$MAYA_PID" 2>/dev/null || true
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -469,23 +469,38 @@ if $run_maya; then
 
   # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
   sudo -E cset shield --exec -- bash -lc '
+  set -euo pipefail
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
+  # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
     > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
+  MAYA_PID=$!
 
+  # Small startup delay to avoid cold-start hiccups
   sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
+  # Verify placement (non-fatal)
+  ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+
+  # Run workload on CPU 6
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
     --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1
+    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1 || true
 
-  kill "$MAYA_PID"
+  # Idempotent teardown with escalation and reap
+  for sig in TERM KILL; do
+    if kill -0 "$MAYA_PID" 2>/dev/null; then
+      kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+      timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+    fi
+    kill -0 "$MAYA_PID" 2>/dev/null || break
+  done
+  wait "$MAYA_PID" 2>/dev/null || true
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -469,23 +469,38 @@ if $run_maya; then
 
   # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
   sudo -E cset shield --exec -- bash -lc '
+  set -euo pipefail
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
+  # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
     > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
+  MAYA_PID=$!
 
+  # Small startup delay to avoid cold-start hiccups
   sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
+  # Verify placement (non-fatal)
+  ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+
+  # Run workload on CPU 6
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
     --lmDir=/local/data/languageModel/ \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1
+    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1 || true
 
-  kill "$MAYA_PID"
+  # Idempotent teardown with escalation and reap
+  for sig in TERM KILL; do
+    if kill -0 "$MAYA_PID" 2>/dev/null; then
+      kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+      timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+    fi
+    kill -0 "$MAYA_PID" 2>/dev/null || break
+  done
+  wait "$MAYA_PID" 2>/dev/null || true
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -469,25 +469,38 @@ if $run_maya; then
 
   # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
   sudo -E cset shield --exec -- bash -lc '
+  set -euo pipefail
   source /local/tools/bci_env/bin/activate
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-  # Start Maya in the background, pinned to CPU 5
+  # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
     > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
+  MAYA_PID=$!
 
+  # Small startup delay to avoid cold-start hiccups
   sleep 1
-  MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-  # Run the workload pinned to CPU 6
+  # Verify placement (non-fatal)
+  ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+
+  # Run workload on CPU 6
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
     --datasetPath=/local/data/ptDecoder_ctc \
     --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1
+    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1 || true
 
-  kill "$MAYA_PID"
+  # Idempotent teardown with escalation and reap
+  for sig in TERM KILL; do
+    if kill -0 "$MAYA_PID" 2>/dev/null; then
+      kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+      timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+    fi
+    kill -0 "$MAYA_PID" 2>/dev/null || break
+  done
+  wait "$MAYA_PID" 2>/dev/null || true
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -433,20 +433,33 @@ if $run_maya; then
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
   sudo -E cset shield --exec -- bash -lc '
+    set -euo pipefail
     source /local/tools/compression_env/bin/activate
 
-    # Start Maya in the background, pinned to CPU 5
+    # Start Maya on CPU 5 in background; capture PID immediately
     taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
       > /local/data/results/id_3_maya.txt 2>&1 &
+    MAYA_PID=$!
 
+    # Small startup delay to avoid cold-start hiccups
     sleep 1
-    MAYA_PID=$(pgrep -n -f "Dist/Release/Maya")
 
-    # Run the workload pinned to CPU 6
+    # Verify placement (non-fatal)
+    ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+
+    # Run workload on CPU 6
     taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_maya.csv \
-      >> /local/data/results/id_3_maya.log 2>&1
+      >> /local/data/results/id_3_maya.log 2>&1 || true
 
-    kill "$MAYA_PID"
+    # Idempotent teardown with escalation and reap
+    for sig in TERM KILL; do
+      if kill -0 "$MAYA_PID" 2>/dev/null; then
+        kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+        timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+      fi
+      kill -0 "$MAYA_PID" 2>/dev/null || break
+    done
+    wait "$MAYA_PID" 2>/dev/null || true
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"


### PR DESCRIPTION
## Summary
- ensure Maya runs with captured PID and robust teardown in run scripts
- add ps verification and TERM/KILL escalation for Maya across workloads

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh`

------
https://chatgpt.com/codex/tasks/task_e_689baaf630c0832c8f3f3ef7ea19c186