### PR TITLE
Standardize section banners in run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -246,6 +246,8 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo
+echo "----------------------------"
 echo "Power and frequency settings"
 echo "----------------------------"
 
@@ -372,22 +374,23 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
-echo
-
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo
+echo "----------------------------"
 echo "CPU shielding"
-echo "-------------"
+echo "----------------------------"
 sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "----------------------------"
 echo "CPU offlining"
-echo "-------------"
+echo "----------------------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -246,6 +246,8 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo
+echo "----------------------------"
 echo "Power and frequency settings"
 echo "----------------------------"
 
@@ -396,22 +398,23 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
-echo
-
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo
+echo "----------------------------"
 echo "CPU shielding"
-echo "-------------"
+echo "----------------------------"
 sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "----------------------------"
 echo "CPU offlining"
-echo "-------------"
+echo "----------------------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -246,6 +246,8 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo
+echo "----------------------------"
 echo "Power and frequency settings"
 echo "----------------------------"
 
@@ -416,22 +418,23 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
-echo
-
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo
+echo "----------------------------"
 echo "CPU shielding"
-echo "-------------"
+echo "----------------------------"
 sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "----------------------------"
 echo "CPU offlining"
-echo "-------------"
+echo "----------------------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -246,6 +246,8 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo
+echo "----------------------------"
 echo "Power and frequency settings"
 echo "----------------------------"
 
@@ -416,22 +418,23 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
-echo
-
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo
+echo "----------------------------"
 echo "CPU shielding"
-echo "-------------"
+echo "----------------------------"
 sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "----------------------------"
 echo "CPU offlining"
-echo "-------------"
+echo "----------------------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -246,6 +246,8 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo
+echo "----------------------------"
 echo "Power and frequency settings"
 echo "----------------------------"
 
@@ -416,22 +418,23 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
-echo
-
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo
+echo "----------------------------"
 echo "CPU shielding"
-echo "-------------"
+echo "----------------------------"
 sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "----------------------------"
 echo "CPU offlining"
-echo "-------------"
+echo "----------------------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -246,6 +246,8 @@ if [ -z "${CPU_LIST:-}" ]; then
   [ -z "$CPU_LIST" ] && CPU_LIST="0"
 fi
 
+echo
+echo "----------------------------"
 echo "Power and frequency settings"
 echo "----------------------------"
 
@@ -382,22 +384,23 @@ fi
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
   echo "PCM profiling finished at: $(timestamp)"
 fi
-echo
-
 ################################################################################
 ### 5. Shield Core 8 (CPU 5) and Core 9 (CPU 6)
 ###    (reserve them for our measurement + workload)
 ################################################################################
+echo
+echo "----------------------------"
 echo "CPU shielding"
-echo "-------------"
+echo "----------------------------"
 sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
 ### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
 ################################################################################
+echo "----------------------------"
 echo "CPU offlining"
-echo "-------------"
+echo "----------------------------"
 KEEP_CPUS="0,5,6"
 
 echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"


### PR DESCRIPTION
## Summary
- ensure Power and frequency settings banner is surrounded by consistent dashes
- add matching top and bottom banners for CPU shielding and offlining
- keep dash length uniform across run scripts
- insert blank line before CPU shielding section

## Testing
- `shellcheck --severity=error scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh && echo 'shellcheck passed'`


------
https://chatgpt.com/codex/tasks/task_e_689bb3c65898832c83c8c1a3cad7293d