### PR TITLE
Use portable cpuset verification in run scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,6 @@ Run scripts now print the applied turbo state, RAPL power limits and frequency
 settings after configuration to help verify the environment before execution.
 Before Maya or Toplev profiling, they offline all CPUs except 0,5,6 and disable
 SMT, restoring the original CPU state once profiling completes.
+Process placement is now verified without using the fragile `ps cpuset` column;
+run scripts print the Maya PID, its current CPU and CPU affinity via `ps` and
+`taskset`, followed by the cpuset or cgroup path from `/proc`.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -436,8 +436,15 @@ if $run_maya; then
     # Small startup delay to avoid cold-start hiccups
     sleep 1
 
-    # Verify placement (non-fatal)
-    ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+    # Portable verification (no 'ps ... cpuset')
+    {
+      echo "[verify] maya pid=$MAYA_PID"
+      ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+      taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+      # cpuset/cgroup path (v1 or v2)
+      cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+      cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+    } || true
 
     # Run workload on CPU 6
     taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1 || true

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -463,8 +463,15 @@ if $run_maya; then
     # Small startup delay to avoid cold-start hiccups
     sleep 1
 
-    # Verify placement (non-fatal)
-    ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+    # Portable verification (no 'ps ... cpuset')
+    {
+      echo "[verify] maya pid=$MAYA_PID"
+      ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+      taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+      # cpuset/cgroup path (v1 or v2)
+      cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+      cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+    } || true
 
     # Run workload on CPU 6
     taskset -c 6 /local/tools/matlab/bin/matlab \

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -486,8 +486,15 @@ if $run_maya; then
   # Small startup delay to avoid cold-start hiccups
   sleep 1
 
-  # Verify placement (non-fatal)
-  ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+  # Portable verification (no 'ps ... cpuset')
+  {
+    echo "[verify] maya pid=$MAYA_PID"
+    ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+    taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+    # cpuset/cgroup path (v1 or v2)
+    cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+    cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+  } || true
 
   # Run workload on CPU 6
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -486,8 +486,15 @@ if $run_maya; then
   # Small startup delay to avoid cold-start hiccups
   sleep 1
 
-  # Verify placement (non-fatal)
-  ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+  # Portable verification (no 'ps ... cpuset')
+  {
+    echo "[verify] maya pid=$MAYA_PID"
+    ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+    taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+    # cpuset/cgroup path (v1 or v2)
+    cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+    cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+  } || true
 
   # Run workload on CPU 6
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -447,8 +447,15 @@ if $run_maya; then
     # Small startup delay to avoid cold-start hiccups
     sleep 1
 
-    # Verify placement (non-fatal)
-    ps -o pid,psr,cpuset,comm -p "$MAYA_PID" || true
+    # Portable verification (no 'ps ... cpuset')
+    {
+      echo "[verify] maya pid=$MAYA_PID"
+      ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+      taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+      # cpuset/cgroup path (v1 or v2)
+      cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+      cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+    } || true
 
     # Run workload on CPU 6
     taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_maya.csv \


### PR DESCRIPTION
## Summary
- avoid `ps` cpuset column by verifying Maya placement with `ps`, `taskset`, and `/proc`
- document portable placement verification in repository guide

## Testing
- `for f in scripts/run_*.sh; do echo "Checking $f"; bash -n "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689bc0a437cc832cb7a1cb555391bb08