### PR TITLE
Fix SMT restoration order in run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -591,15 +591,25 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_pcie.log
 
 ################################################################################
-### 14. Restore CPUs and SMT
+### 14. Restore SMT and CPUs
 ################################################################################
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  if [ -w "$cpu_dir/online" ]; then
-    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
-  fi
-done
+
+# 1) Re-enable SMT first
 if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
+  # tiny settle to avoid races
+  sleep 0.1
 fi
-echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# 2) Then online all hotpluggable CPUs
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  online="$cpu_dir/online"
+  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
+  [ -w "$online" ] || continue
+  echo 1 | sudo tee "$online" >/dev/null || true
+done
+
+# (optional) Remove the shielded cpusets so future runs start clean
+sudo cset shield --reset || true
+
+echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -632,15 +632,25 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_pcie.log
 
 ################################################################################
-### 14. Restore CPUs and SMT
+### 14. Restore SMT and CPUs
 ################################################################################
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  if [ -w "$cpu_dir/online" ]; then
-    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
-  fi
-done
+
+# 1) Re-enable SMT first
 if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
+  # tiny settle to avoid races
+  sleep 0.1
 fi
-echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# 2) Then online all hotpluggable CPUs
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  online="$cpu_dir/online"
+  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
+  [ -w "$online" ] || continue
+  echo 1 | sudo tee "$online" >/dev/null || true
+done
+
+# (optional) Remove the shielded cpusets so future runs start clean
+sudo cset shield --reset || true
+
+echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -659,15 +659,25 @@ rm -f /local/data/results/done_llm_toplev_basic.log \
       /local/data/results/done_llm_pcm_pcie.log
 
 ################################################################################
-### 14. Restore CPUs and SMT
+### 14. Restore SMT and CPUs
 ################################################################################
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  if [ -w "$cpu_dir/online" ]; then
-    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
-  fi
-done
+
+# 1) Re-enable SMT first
 if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
+  # tiny settle to avoid races
+  sleep 0.1
 fi
-echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# 2) Then online all hotpluggable CPUs
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  online="$cpu_dir/online"
+  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
+  [ -w "$online" ] || continue
+  echo 1 | sudo tee "$online" >/dev/null || true
+done
+
+# (optional) Remove the shielded cpusets so future runs start clean
+sudo cset shield --reset || true
+
+echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -659,15 +659,25 @@ rm -f /local/data/results/done_lm_toplev_basic.log \
       /local/data/results/done_lm_pcm_pcie.log
 
 ################################################################################
-### 14. Restore CPUs and SMT
+### 14. Restore SMT and CPUs
 ################################################################################
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  if [ -w "$cpu_dir/online" ]; then
-    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
-  fi
-done
+
+# 1) Re-enable SMT first
 if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
+  # tiny settle to avoid races
+  sleep 0.1
 fi
-echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# 2) Then online all hotpluggable CPUs
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  online="$cpu_dir/online"
+  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
+  [ -w "$online" ] || continue
+  echo 1 | sudo tee "$online" >/dev/null || true
+done
+
+# (optional) Remove the shielded cpusets so future runs start clean
+sudo cset shield --reset || true
+
+echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -604,15 +604,25 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_pcie.log
 
 ################################################################################
-### 14. Restore CPUs and SMT
+### 14. Restore SMT and CPUs
 ################################################################################
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  if [ -w "$cpu_dir/online" ]; then
-    echo 1 | sudo tee "$cpu_dir/online" >/dev/null || true
-  fi
-done
+
+# 1) Re-enable SMT first
 if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
+  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
+  # tiny settle to avoid races
+  sleep 0.1
 fi
-echo "Restored. Online CPUs: $(cat /sys/devices/system/cpu/online)"
+
+# 2) Then online all hotpluggable CPUs
+for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+  online="$cpu_dir/online"
+  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
+  [ -w "$online" ] || continue
+  echo 1 | sudo tee "$online" >/dev/null || true
+done
+
+# (optional) Remove the shielded cpusets so future runs start clean
+sudo cset shield --reset || true
+
+echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"


### PR DESCRIPTION
## Summary
- ensure SMT is re-enabled before bringing CPUs back online in run scripts
- clean up shielded cpusets after profiling

## Testing
- `bash -n scripts/run_1.sh`
- `bash -n scripts/run_3.sh`
- `bash -n scripts/run_13.sh`
- `bash -n scripts/run_20_3gram_lm.sh`
- `bash -n scripts/run_20_3gram_llm.sh`
- `bash -n scripts/run_20_3gram_rnn.sh`

------
https://chatgpt.com/codex/tasks/task_e_689bc57a9fc0832c83385383a7ac90a6