### PR TITLE
Add tool banners before profiling runs

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -300,6 +300,10 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  echo
+  echo "----------------------------"
+  echo "PCM-PCIE"
+  echo "----------------------------"
   idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -318,6 +322,10 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  echo
+  echo "----------------------------"
+  echo "PCM"
+  echo "----------------------------"
   idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -336,6 +344,10 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  echo
+  echo "----------------------------"
+  echo "PCM-MEMORY"
+  echo "----------------------------"
   idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
@@ -354,6 +366,10 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  echo
+  echo "----------------------------"
+  echo "PCM-POWER"
+  echo "----------------------------"
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
@@ -422,6 +438,10 @@ echo
 ################################################################################
 
 if $run_maya; then
+  echo
+  echo "----------------------------"
+  echo "MAYA"
+  echo "----------------------------"
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
@@ -472,6 +492,10 @@ echo
 ################################################################################
 
 if $run_toplev_basic; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV BASIC"
+  echo "----------------------------"
   idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
@@ -496,6 +520,10 @@ echo
 ################################################################################
 
 if $run_toplev_execution; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV EXECUTION"
+  echo "----------------------------"
   idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
@@ -519,6 +547,10 @@ echo
 ################################################################################
 
 if $run_toplev_full; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV FULL"
+  echo "----------------------------"
   idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -300,6 +300,10 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  echo
+  echo "----------------------------"
+  echo "PCM-PCIE"
+  echo "----------------------------"
   idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -324,6 +328,10 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  echo
+  echo "----------------------------"
+  echo "PCM"
+  echo "----------------------------"
   idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -348,6 +356,10 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  echo
+  echo "----------------------------"
+  echo "PCM-MEMORY"
+  echo "----------------------------"
   idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
@@ -372,6 +384,10 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  echo
+  echo "----------------------------"
+  echo "PCM-POWER"
+  echo "----------------------------"
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
@@ -446,6 +462,10 @@ echo
 ################################################################################
 
 if $run_maya; then
+  echo
+  echo "----------------------------"
+  echo "MAYA"
+  echo "----------------------------"
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
@@ -502,6 +522,10 @@ echo
 ################################################################################
 
 if $run_toplev_basic; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV BASIC"
+  echo "----------------------------"
   idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
@@ -532,6 +556,10 @@ echo
 ################################################################################
 
 if $run_toplev_execution; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV EXECUTION"
+  echo "----------------------------"
   idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
@@ -560,6 +588,10 @@ echo
 ################################################################################
 
 if $run_toplev_full; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV FULL"
+  echo "----------------------------"
   idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -300,6 +300,10 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  echo
+  echo "----------------------------"
+  echo "PCM-PCIE"
+  echo "----------------------------"
   idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -329,6 +333,10 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  echo
+  echo "----------------------------"
+  echo "PCM"
+  echo "----------------------------"
   idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -358,6 +366,10 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  echo
+  echo "----------------------------"
+  echo "PCM-MEMORY"
+  echo "----------------------------"
   idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
@@ -387,6 +399,10 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  echo
+  echo "----------------------------"
+  echo "PCM-POWER"
+  echo "----------------------------"
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
@@ -466,6 +482,10 @@ echo
 ################################################################################
 
 if $run_maya; then
+  echo
+  echo "----------------------------"
+  echo "MAYA"
+  echo "----------------------------"
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
@@ -525,6 +545,10 @@ echo
 ################################################################################
 
 if $run_toplev_basic; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV BASIC"
+  echo "----------------------------"
   idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
@@ -556,6 +580,10 @@ echo
 ################################################################################
 
 if $run_toplev_execution; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV EXECUTION"
+  echo "----------------------------"
   idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
@@ -585,6 +613,10 @@ echo
 ################################################################################
 
 if $run_toplev_full; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV FULL"
+  echo "----------------------------"
   idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -300,6 +300,10 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  echo
+  echo "----------------------------"
+  echo "PCM-PCIE"
+  echo "----------------------------"
   idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -329,6 +333,10 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  echo
+  echo "----------------------------"
+  echo "PCM"
+  echo "----------------------------"
   idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -358,6 +366,10 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  echo
+  echo "----------------------------"
+  echo "PCM-MEMORY"
+  echo "----------------------------"
   idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
@@ -387,6 +399,10 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  echo
+  echo "----------------------------"
+  echo "PCM-POWER"
+  echo "----------------------------"
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
@@ -466,6 +482,10 @@ echo
 ################################################################################
 
 if $run_maya; then
+  echo
+  echo "----------------------------"
+  echo "MAYA"
+  echo "----------------------------"
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
@@ -525,6 +545,10 @@ echo
 ################################################################################
 
 if $run_toplev_basic; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV BASIC"
+  echo "----------------------------"
   idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
@@ -557,6 +581,10 @@ echo
 ################################################################################
 
 if $run_toplev_execution; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV EXECUTION"
+  echo "----------------------------"
   idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
@@ -586,6 +614,10 @@ echo
 ################################################################################
 
 if $run_toplev_full; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV FULL"
+  echo "----------------------------"
   idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -300,6 +300,10 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  echo
+  echo "----------------------------"
+  echo "PCM-PCIE"
+  echo "----------------------------"
   idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -329,6 +333,10 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  echo
+  echo "----------------------------"
+  echo "PCM"
+  echo "----------------------------"
   idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -358,6 +366,10 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  echo
+  echo "----------------------------"
+  echo "PCM-MEMORY"
+  echo "----------------------------"
   idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
@@ -387,6 +399,10 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  echo
+  echo "----------------------------"
+  echo "PCM-POWER"
+  echo "----------------------------"
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
@@ -466,6 +482,10 @@ echo
 ################################################################################
 
 if $run_maya; then
+  echo
+  echo "----------------------------"
+  echo "MAYA"
+  echo "----------------------------"
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
@@ -525,6 +545,10 @@ echo
 ################################################################################
 
 if $run_toplev_basic; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV BASIC"
+  echo "----------------------------"
   idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
@@ -557,6 +581,10 @@ echo
 ################################################################################
 
 if $run_toplev_execution; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV EXECUTION"
+  echo "----------------------------"
   idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
@@ -586,6 +614,10 @@ echo
 ################################################################################
 
 if $run_toplev_full; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV FULL"
+  echo "----------------------------"
   idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -302,6 +302,10 @@ if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
 fi
 
 if $run_pcm_pcie; then
+  echo
+  echo "----------------------------"
+  echo "PCM-PCIE"
+  echo "----------------------------"
   idle_wait
   echo "pcm-pcie started at: $(timestamp)"
   pcm_pcie_start=$(date +%s)
@@ -322,6 +326,10 @@ if $run_pcm_pcie; then
 fi
 
 if $run_pcm; then
+  echo
+  echo "----------------------------"
+  echo "PCM"
+  echo "----------------------------"
   idle_wait
   echo "pcm started at: $(timestamp)"
   pcm_start=$(date +%s)
@@ -342,6 +350,10 @@ if $run_pcm; then
 fi
 
 if $run_pcm_memory; then
+  echo
+  echo "----------------------------"
+  echo "PCM-MEMORY"
+  echo "----------------------------"
   idle_wait
   echo "pcm-memory started at: $(timestamp)"
   pcm_mem_start=$(date +%s)
@@ -362,6 +374,10 @@ if $run_pcm_memory; then
 fi
 
 if $run_pcm_power; then
+  echo
+  echo "----------------------------"
+  echo "PCM-POWER"
+  echo "----------------------------"
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
@@ -432,6 +448,10 @@ echo
 ################################################################################
 
 if $run_maya; then
+  echo
+  echo "----------------------------"
+  echo "MAYA"
+  echo "----------------------------"
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
@@ -484,6 +504,10 @@ echo
 ################################################################################
 
 if $run_toplev_basic; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV BASIC"
+  echo "----------------------------"
   idle_wait
   echo "Toplev basic profiling started at: $(timestamp)"
   toplev_basic_start=$(date +%s)
@@ -510,6 +534,10 @@ echo
 ################################################################################
 
 if $run_toplev_execution; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV EXECUTION"
+  echo "----------------------------"
   idle_wait
   echo "Toplev execution profiling started at: $(timestamp)"
   toplev_execution_start=$(date +%s)
@@ -534,6 +562,10 @@ echo
 ################################################################################
 
 if $run_toplev_full; then
+  echo
+  echo "----------------------------"
+  echo "TOPLEV FULL"
+  echo "----------------------------"
   idle_wait
   echo "Toplev full profiling started at: $(timestamp)"
   toplev_full_start=$(date +%s)


### PR DESCRIPTION
## Summary
- Print dashed-line banners naming each tool (PCM variants, Maya, and Toplev modes) before execution
- Applied updates across all run scripts for consistent logging

## Testing
- `shellcheck scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_llm.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c71f040ac832ca8720d8f8721b779