### PR TITLE
Remove CPU offlining from run scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,9 @@ the file is missing or empty so repeated runs start with a clean slate.
 
 Run scripts now print the applied turbo state, RAPL power limits and frequency
 settings after configuration to help verify the environment before execution.
-Before Maya or Toplev profiling, they offline all CPUs except 0,5,6 and disable
-SMT, restoring the original CPU state once profiling completes.
+Before Maya or Toplev profiling, they shield CPUs 5 and 6 for profiler/workload
+isolation but leave the rest of the system online so measurement tools (e.g.,
+Maya, pcm-pcie) see the expected topology.
 Process placement is now verified without using the fragile `ps cpuset` column;
 run scripts print the Maya PID, its current CPU and CPU affinity via `ps` and
 `taskset`, followed by the cpuset or cgroup path from `/proc`.

--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -402,39 +402,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
-### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
-################################################################################
-echo "----------------------------"
-echo "CPU offlining"
-echo "----------------------------"
-KEEP_CPUS="0,5,6"
-
-echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
-
-# Prefer global SMT control if available
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
-fi
-
-# Offline all CPUs not in KEEP_CPUS
-keep_set=",$KEEP_CPUS,"
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  case "$keep_set" in
-    *,"$cpu",*) ;;  # keep
-    *)
-      if [ -w "$cpu_dir/online" ]; then
-        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
-      fi
-      ;;
-  esac
-done
-
-echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
-echo
-
-################################################################################
-### 7. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -488,7 +456,7 @@ fi
 echo
 
 ################################################################################
-### 8. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -516,7 +484,7 @@ fi
 echo
 
 ################################################################################
-### 9. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -543,7 +511,7 @@ fi
 echo
 
 ################################################################################
-### 10. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -570,7 +538,7 @@ fi
 echo
 
 ################################################################################
-### 11. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -587,13 +555,13 @@ fi
 echo
 
 ################################################################################
-### 12. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 13. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"
@@ -623,25 +591,7 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_pcie.log
 
 ################################################################################
-### 14. Restore SMT and CPUs
+### 13. Clean up CPU shielding
 ################################################################################
 
-# 1) Re-enable SMT first
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
-  # tiny settle to avoid races
-  sleep 0.1
-fi
-
-# 2) Then online all hotpluggable CPUs
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  online="$cpu_dir/online"
-  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
-  [ -w "$online" ] || continue
-  echo 1 | sudo tee "$online" >/dev/null || true
-done
-
-# (optional) Remove the shielded cpusets so future runs start clean
 sudo cset shield --reset || true
-
-echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -426,39 +426,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
-### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
-################################################################################
-echo "----------------------------"
-echo "CPU offlining"
-echo "----------------------------"
-KEEP_CPUS="0,5,6"
-
-echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
-
-# Prefer global SMT control if available
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
-fi
-
-# Offline all CPUs not in KEEP_CPUS
-keep_set=",$KEEP_CPUS,"
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  case "$keep_set" in
-    *,"$cpu",*) ;;  # keep
-    *)
-      if [ -w "$cpu_dir/online" ]; then
-        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
-      fi
-      ;;
-  esac
-done
-
-echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
-echo
-
-################################################################################
-### 7. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -518,7 +486,7 @@ fi
 echo
 
 ################################################################################
-### 8. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -552,7 +520,7 @@ fi
 echo
 
 ################################################################################
-### 9. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -584,7 +552,7 @@ fi
 echo
 
 ################################################################################
-### 10. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -616,7 +584,7 @@ fi
 echo
 
 ################################################################################
-### 11. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -627,13 +595,13 @@ fi
 echo
 
 ################################################################################
-### 12. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 13. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {
@@ -664,25 +632,7 @@ rm -f /local/data/results/done_toplev_basic.log \
       /local/data/results/done_pcm_pcie.log
 
 ################################################################################
-### 14. Restore SMT and CPUs
+### 13. Clean up CPU shielding
 ################################################################################
 
-# 1) Re-enable SMT first
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
-  # tiny settle to avoid races
-  sleep 0.1
-fi
-
-# 2) Then online all hotpluggable CPUs
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  online="$cpu_dir/online"
-  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
-  [ -w "$online" ] || continue
-  echo 1 | sudo tee "$online" >/dev/null || true
-done
-
-# (optional) Remove the shielded cpusets so future runs start clean
 sudo cset shield --reset || true
-
-echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -446,39 +446,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
-### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
-################################################################################
-echo "----------------------------"
-echo "CPU offlining"
-echo "----------------------------"
-KEEP_CPUS="0,5,6"
-
-echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
-
-# Prefer global SMT control if available
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
-fi
-
-# Offline all CPUs not in KEEP_CPUS
-keep_set=",$KEEP_CPUS,"
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  case "$keep_set" in
-    *,"$cpu",*) ;;  # keep
-    *)
-      if [ -w "$cpu_dir/online" ]; then
-        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
-      fi
-      ;;
-  esac
-done
-
-echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
-echo
-
-################################################################################
-### 7. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -541,7 +509,7 @@ fi
 echo
 
 ################################################################################
-### 8. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -576,7 +544,7 @@ fi
 echo
 
 ################################################################################
-### 9. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -609,7 +577,7 @@ fi
 echo
 
 ################################################################################
-### 10. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -642,7 +610,7 @@ fi
 echo
 
 ################################################################################
-### 11. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -654,13 +622,13 @@ fi
 echo
 
 ################################################################################
-### 12. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 13. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {
@@ -691,25 +659,7 @@ rm -f /local/data/results/done_llm_toplev_basic.log \
       /local/data/results/done_llm_pcm_pcie.log
 
 ################################################################################
-### 14. Restore SMT and CPUs
+### 13. Clean up CPU shielding
 ################################################################################
 
-# 1) Re-enable SMT first
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
-  # tiny settle to avoid races
-  sleep 0.1
-fi
-
-# 2) Then online all hotpluggable CPUs
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  online="$cpu_dir/online"
-  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
-  [ -w "$online" ] || continue
-  echo 1 | sudo tee "$online" >/dev/null || true
-done
-
-# (optional) Remove the shielded cpusets so future runs start clean
 sudo cset shield --reset || true
-
-echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -446,39 +446,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
-### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
-################################################################################
-echo "----------------------------"
-echo "CPU offlining"
-echo "----------------------------"
-KEEP_CPUS="0,5,6"
-
-echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
-
-# Prefer global SMT control if available
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
-fi
-
-# Offline all CPUs not in KEEP_CPUS
-keep_set=",$KEEP_CPUS,"
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  case "$keep_set" in
-    *,"$cpu",*) ;;  # keep
-    *)
-      if [ -w "$cpu_dir/online" ]; then
-        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
-      fi
-      ;;
-  esac
-done
-
-echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
-echo
-
-################################################################################
-### 7. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -541,7 +509,7 @@ fi
 echo
 
 ################################################################################
-### 8. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -577,7 +545,7 @@ fi
 echo
 
 ################################################################################
-### 9. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -610,7 +578,7 @@ fi
 echo
 
 ################################################################################
-### 10. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -642,7 +610,7 @@ if $run_toplev_full; then
 fi
 echo
 ################################################################################
-### 11. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -654,13 +622,13 @@ fi
 echo
 
 ################################################################################
-### 12. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 13. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 
 {
@@ -691,25 +659,7 @@ rm -f /local/data/results/done_lm_toplev_basic.log \
       /local/data/results/done_lm_pcm_pcie.log
 
 ################################################################################
-### 14. Restore SMT and CPUs
+### 13. Clean up CPU shielding
 ################################################################################
 
-# 1) Re-enable SMT first
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
-  # tiny settle to avoid races
-  sleep 0.1
-fi
-
-# 2) Then online all hotpluggable CPUs
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  online="$cpu_dir/online"
-  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
-  [ -w "$online" ] || continue
-  echo 1 | sudo tee "$online" >/dev/null || true
-done
-
-# (optional) Remove the shielded cpusets so future runs start clean
 sudo cset shield --reset || true
-
-echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -446,39 +446,7 @@ sudo cset shield --cpu 5,6 --kthread=on
 echo
 
 ################################################################################
-### 6. CPU offlining: keep only CPUs 0,5,6 online (SMT siblings off)
-################################################################################
-echo "----------------------------"
-echo "CPU offlining"
-echo "----------------------------"
-KEEP_CPUS="0,5,6"
-
-echo "Before offlining, online CPUs: $(cat /sys/devices/system/cpu/online)"
-
-# Prefer global SMT control if available
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo off | sudo tee /sys/devices/system/cpu/smt/control >/dev/null
-fi
-
-# Offline all CPUs not in KEEP_CPUS
-keep_set=",$KEEP_CPUS,"
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  cpu=${cpu_dir##*/cpu}
-  case "$keep_set" in
-    *,"$cpu",*) ;;  # keep
-    *)
-      if [ -w "$cpu_dir/online" ]; then
-        echo 0 | sudo tee "$cpu_dir/online" >/dev/null || true
-      fi
-      ;;
-  esac
-done
-
-echo "After offlining, online CPUs:  $(cat /sys/devices/system/cpu/online)"
-echo
-
-################################################################################
-### 7. Maya profiling
+### 6. Maya profiling
 ################################################################################
 
 if $run_maya; then
@@ -541,7 +509,7 @@ fi
 echo
 
 ################################################################################
-### 8. Toplev basic profiling
+### 7. Toplev basic profiling
 ################################################################################
 
 if $run_toplev_basic; then
@@ -577,7 +545,7 @@ fi
 echo
 
 ################################################################################
-### 9. Toplev execution profiling
+### 8. Toplev execution profiling
 ################################################################################
 
 if $run_toplev_execution; then
@@ -610,7 +578,7 @@ fi
 echo
 
 ################################################################################
-### 10. Toplev full profiling
+### 9. Toplev full profiling
 ################################################################################
 
 if $run_toplev_full; then
@@ -644,7 +612,7 @@ fi
 echo
 
 ################################################################################
-### 11. Convert Maya raw output files into CSV
+### 10. Convert Maya raw output files into CSV
 ################################################################################
 
 if $run_maya; then
@@ -656,13 +624,13 @@ fi
 echo
 
 ################################################################################
-### 12. Signal completion for tmux monitoring
+### 11. Signal completion for tmux monitoring
 ################################################################################
 echo "All done. Results are in /local/data/results/"
 echo "Experiment finished at: $(timestamp)"
 
 ################################################################################
-### 13. Write completion file with runtimes
+### 12. Write completion file with runtimes
 ################################################################################
 {
   echo "Done"
@@ -692,25 +660,7 @@ rm -f /local/data/results/done_rnn_toplev_basic.log \
       /local/data/results/done_rnn_pcm_pcie.log
 
 ################################################################################
-### 14. Restore SMT and CPUs
+### 13. Clean up CPU shielding
 ################################################################################
 
-# 1) Re-enable SMT first
-if [ -w /sys/devices/system/cpu/smt/control ]; then
-  echo on | sudo tee /sys/devices/system/cpu/smt/control >/dev/null || true
-  # tiny settle to avoid races
-  sleep 0.1
-fi
-
-# 2) Then online all hotpluggable CPUs
-for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
-  online="$cpu_dir/online"
-  # some CPUs (e.g., cpu0) may not have an 'online' file or it may be RO
-  [ -w "$online" ] || continue
-  echo 1 | sudo tee "$online" >/dev/null || true
-done
-
-# (optional) Remove the shielded cpusets so future runs start clean
 sudo cset shield --reset || true
-
-echo "Restored. SMT=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo '?'), Online CPUs: $(cat /sys/devices/system/cpu/online)"


### PR DESCRIPTION
## Summary
- remove CPU/SMP offlining from every run script so measurement tools see the full topology
- keep CPU shielding cleanup while renumbering the remaining profiling steps
- update the agent guide to describe the new behaviour

## Testing
- not run (shell changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cae1011068832cb840f1dfeac5fa2f