### PR TITLE
Update startup_13 prompt for bulk VPN configuration input

### DIFF
--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -26,9 +26,9 @@ for var in "${required_vars[@]}"; do
 done
 
 if (( ${#missing[@]} )); then
-  echo "The following configuration values are missing: ${missing[*]}"
-  echo "Please provide them now as VAR=VALUE entries."
-  echo "Use a trailing \\ to continue onto the next line if needed."
+  echo "The VPN configuration values are missing. Please provide them."
+  echo "Enter each value as VAR=VALUE and paste them all at once."
+  echo "Use a trailing \\ at the end of a line to continue input if desired."
 
   config_lines=()
   while true; do


### PR DESCRIPTION
## Summary
- align the startup_13 VPN configuration prompt with the new messaging
- clarify that all configuration assignments can be pasted at once when providing values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1b645578832cb40fbc9d54486bba