### PR TITLE
Add -A flag to toplev basic invocations

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -470,7 +470,7 @@ if $run_toplev_basic; then
   sudo -E cset shield --exec -- sh -c '
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      --per-thread --columns \
+      -A --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_1_toplev_basic.csv -- \
         taskset -c 6 /local/bci_code/id_1/main \

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -504,7 +504,7 @@ if $run_toplev_basic; then
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      --per-thread --columns \
+      -A --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_13_toplev_basic.csv -- \
         taskset -c 6 /local/tools/matlab/bin/matlab \

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -528,7 +528,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    --per-thread --columns \
+    -A --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_llm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -528,7 +528,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    --per-thread --columns \
+    -A --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_lm_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -528,7 +528,7 @@ if $run_toplev_basic; then
 
   taskset -c 5 /local/tools/pmu-tools/toplev \
     -l3 -I 500 -v --no-multiplex \
-    --per-thread --columns \
+    -A --per-thread --columns \
     --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
     -o /local/data/results/id_20_3gram_rnn_toplev_basic.csv -- \
       taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -484,7 +484,7 @@ if $run_toplev_basic; then
 
     taskset -c 5 /local/tools/pmu-tools/toplev \
       -l3 -I 500 -v --no-multiplex \
-      --per-thread --columns \
+      -A --per-thread --columns \
       --nodes "!Instructions,CPI,L1MPKI,L2MPKI,L3MPKI,Backend_Bound.Memory_Bound*/3,IpBranch,IpCall,IpLoad,IpStore" -m -x, \
       -o /local/data/results/id_3_toplev_basic.csv -- \
         taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_toplev_basic.csv


### PR DESCRIPTION
## Summary
- add the -A flag to every toplev basic command so it runs in aggregate mode while still reporting per-thread columns

## Testing
- for f in scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh; do bash -n "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68cb24908070832c8216746fd30f9889