### PR TITLE
Prevent tmux relaunch when requesting run script help

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 ### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
 ################################################################################
 
+# Detect help requests early so we can show usage without spawning tmux
+request_help=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      request_help=true
+      break
+      ;;
+  esac
+done
+
 # Start tmux session if running outside tmux
-if [[ -z ${TMUX:-} ]]; then
+if [[ -z ${TMUX:-} && $request_help == "false" ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 ### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
 ################################################################################
 
+# Detect help requests early so we can show usage without spawning tmux
+request_help=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      request_help=true
+      break
+      ;;
+  esac
+done
+
 # Start tmux session if running outside tmux
-if [[ -z ${TMUX:-} ]]; then
+if [[ -z ${TMUX:-} && $request_help == "false" ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 ### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
 ################################################################################
 
+# Detect help requests early so we can show usage without spawning tmux
+request_help=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      request_help=true
+      break
+      ;;
+  esac
+done
+
 # Start tmux session if running outside tmux
-if [[ -z ${TMUX:-} ]]; then
+if [[ -z ${TMUX:-} && $request_help == "false" ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 ### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
 ################################################################################
 
+# Detect help requests early so we can show usage without spawning tmux
+request_help=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      request_help=true
+      break
+      ;;
+  esac
+done
+
 # Start tmux session if running outside tmux
-if [[ -z ${TMUX:-} ]]; then
+if [[ -z ${TMUX:-} && $request_help == "false" ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 ### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
 ################################################################################
 
+# Detect help requests early so we can show usage without spawning tmux
+request_help=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      request_help=true
+      break
+      ;;
+  esac
+done
+
 # Start tmux session if running outside tmux
-if [[ -z ${TMUX:-} ]]; then
+if [[ -z ${TMUX:-} && $request_help == "false" ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 ### 0. Initialize environment (tmux, logging, CLI parsing, helpers)
 ################################################################################
 
+# Detect help requests early so we can show usage without spawning tmux
+request_help=false
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      request_help=true
+      break
+      ;;
+  esac
+done
+
 # Start tmux session if running outside tmux
-if [[ -z ${TMUX:-} ]]; then
+if [[ -z ${TMUX:-} && $request_help == "false" ]]; then
   session_name="$(basename "$0" .sh)"
   script_path="$(readlink -f "$0")"
   echo "Running outside tmux. Starting tmux session '$session_name'."


### PR DESCRIPTION
## Summary
- detect -h/--help arguments before launching tmux in each run script
- allow help output to print without triggering the tmux relaunch path

## Testing
- ./scripts/run_1.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68cd87568828832cb592d36aabe90810