### PR TITLE
Add pqos monitoring for pcm-power runs

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -336,6 +336,102 @@ idle_wait() {
   echo
 }
 
+PCM_POWER_SAMPLE_INTERVAL="0.5"
+PQOS_BIN="/usr/bin/pqos"
+PQOS_MONITOR_DURATION=86400
+PQOS_DISCOVERY_TIMEOUT=30
+PQOS_DISCOVERY_INTERVAL=0.2
+
+reset_pqos_state() {
+  sudo "$PQOS_BIN" -R >/dev/null 2>&1 || true
+}
+
+await_workload_pids() {
+  local pattern="$1"
+  local monitor_pid="${2:-}"
+  local timeout="${3:-$PQOS_DISCOVERY_TIMEOUT}"
+  local interval="${4:-$PQOS_DISCOVERY_INTERVAL}"
+  local start_time=$SECONDS
+  local -a pids=()
+
+  while (( SECONDS - start_time < timeout )); do
+    mapfile -t pids < <(pgrep -f -- "$pattern" || true)
+    if (( ${#pids[@]} )); then
+      printf '%s\n' "${pids[@]}"
+      return 0
+    fi
+    if [[ -n "$monitor_pid" ]] && ! kill -0 "$monitor_pid" 2>/dev/null; then
+      break
+    fi
+    sleep "$interval"
+  done
+  return 1
+}
+
+start_pqos_monitor() {
+  local output_file="$1"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 1
+  fi
+
+  local -a monitor_spec_parts=()
+  local pid
+  for pid in "$@"; do
+    monitor_spec_parts+=("pid:$pid")
+  done
+
+  local monitor_spec
+  monitor_spec=$(IFS=';'; echo "${monitor_spec_parts[*]}")
+  local pqos_pid_file
+  pqos_pid_file=$(mktemp)
+
+  if ! sudo env PQOS_BIN="$PQOS_BIN" MONITOR_SPEC="$monitor_spec" PQOS_OUTPUT="$output_file" \
+    PQOS_PID_FILE="$pqos_pid_file" PQOS_INTERVAL="$PCM_POWER_SAMPLE_INTERVAL" \
+    PQOS_DURATION="$PQOS_MONITOR_DURATION" bash -lc '
+      set -e
+      nohup "$PQOS_BIN" -I -u text -m "$MONITOR_SPEC" -i "$PQOS_INTERVAL" -t "$PQOS_DURATION" \
+        > "$PQOS_OUTPUT" 2>&1 &
+      echo $! > "$PQOS_PID_FILE"
+      disown || true
+    '; then
+    rm -f "$pqos_pid_file"
+    return 1
+  fi
+
+  local pqos_pid=""
+  if [[ -f "$pqos_pid_file" ]]; then
+    read -r pqos_pid < "$pqos_pid_file" || true
+    rm -f "$pqos_pid_file"
+  fi
+
+  if [[ -z "$pqos_pid" ]]; then
+    return 1
+  fi
+
+  echo "$pqos_pid"
+  return 0
+}
+
+stop_pqos_monitor() {
+  local pqos_pid="$1"
+  if [[ -z "$pqos_pid" ]]; then
+    return
+  fi
+
+  for sig in TERM KILL; do
+    if sudo kill -0 "$pqos_pid" 2>/dev/null; then
+      sudo kill -s "$sig" "$pqos_pid" 2>/dev/null || true
+      for _ in {1..50}; do
+        if ! sudo kill -0 "$pqos_pid" 2>/dev/null; then
+          break
+        fi
+        sleep 0.2
+      done
+    fi
+  done
+}
+
 ################################################################################
 ### 1. Create results directory and placeholder logs
 ################################################################################
@@ -573,13 +669,41 @@ if $run_pcm_power; then
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
+  reset_pqos_state
+  pqos_pid=""
+  pqos_output="/local/data/results/id_1_pqos_pid.txt"
+  pqos_pattern="/local/bci_code/id_1/main"
+
   sudo sh -c '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
       -csv=/local/data/results/id_1_pcm_power.csv -- \
       taskset -c 6 /local/bci_code/id_1/main \
     >>/local/data/results/id_1_pcm_power.log 2>&1
-  '
+  ' &
+  pcm_power_job_pid=$!
+
+  if mapfile -t pqos_targets < <(await_workload_pids "$pqos_pattern" "$pcm_power_job_pid"); then
+    echo "pqos monitoring workload PID(s): ${pqos_targets[*]}"
+    if pqos_pid=$(start_pqos_monitor "$pqos_output" "${pqos_targets[@]}"); then
+      echo "pqos started with PID $pqos_pid"
+    else
+      echo "Warning: failed to start pqos for PID(s): ${pqos_targets[*]}" >&2
+      pqos_pid=""
+    fi
+  else
+    echo "Warning: unable to discover workload PID(s) for pqos (pattern: $pqos_pattern)" >&2
+  fi
+
+  pcm_power_status=0
+  if ! wait "$pcm_power_job_pid"; then
+    pcm_power_status=$?
+  fi
+  stop_pqos_monitor "$pqos_pid"
+  if (( pcm_power_status != 0 )); then
+    exit "$pcm_power_status"
+  fi
+
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -336,6 +336,102 @@ idle_wait() {
   echo
 }
 
+PCM_POWER_SAMPLE_INTERVAL="0.5"
+PQOS_BIN="/usr/bin/pqos"
+PQOS_MONITOR_DURATION=86400
+PQOS_DISCOVERY_TIMEOUT=30
+PQOS_DISCOVERY_INTERVAL=0.2
+
+reset_pqos_state() {
+  sudo "$PQOS_BIN" -R >/dev/null 2>&1 || true
+}
+
+await_workload_pids() {
+  local pattern="$1"
+  local monitor_pid="${2:-}"
+  local timeout="${3:-$PQOS_DISCOVERY_TIMEOUT}"
+  local interval="${4:-$PQOS_DISCOVERY_INTERVAL}"
+  local start_time=$SECONDS
+  local -a pids=()
+
+  while (( SECONDS - start_time < timeout )); do
+    mapfile -t pids < <(pgrep -f -- "$pattern" || true)
+    if (( ${#pids[@]} )); then
+      printf '%s\n' "${pids[@]}"
+      return 0
+    fi
+    if [[ -n "$monitor_pid" ]] && ! kill -0 "$monitor_pid" 2>/dev/null; then
+      break
+    fi
+    sleep "$interval"
+  done
+  return 1
+}
+
+start_pqos_monitor() {
+  local output_file="$1"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 1
+  fi
+
+  local -a monitor_spec_parts=()
+  local pid
+  for pid in "$@"; do
+    monitor_spec_parts+=("pid:$pid")
+  done
+
+  local monitor_spec
+  monitor_spec=$(IFS=';'; echo "${monitor_spec_parts[*]}")
+  local pqos_pid_file
+  pqos_pid_file=$(mktemp)
+
+  if ! sudo env PQOS_BIN="$PQOS_BIN" MONITOR_SPEC="$monitor_spec" PQOS_OUTPUT="$output_file" \
+    PQOS_PID_FILE="$pqos_pid_file" PQOS_INTERVAL="$PCM_POWER_SAMPLE_INTERVAL" \
+    PQOS_DURATION="$PQOS_MONITOR_DURATION" bash -lc '
+      set -e
+      nohup "$PQOS_BIN" -I -u text -m "$MONITOR_SPEC" -i "$PQOS_INTERVAL" -t "$PQOS_DURATION" \
+        > "$PQOS_OUTPUT" 2>&1 &
+      echo $! > "$PQOS_PID_FILE"
+      disown || true
+    '; then
+    rm -f "$pqos_pid_file"
+    return 1
+  fi
+
+  local pqos_pid=""
+  if [[ -f "$pqos_pid_file" ]]; then
+    read -r pqos_pid < "$pqos_pid_file" || true
+    rm -f "$pqos_pid_file"
+  fi
+
+  if [[ -z "$pqos_pid" ]]; then
+    return 1
+  fi
+
+  echo "$pqos_pid"
+  return 0
+}
+
+stop_pqos_monitor() {
+  local pqos_pid="$1"
+  if [[ -z "$pqos_pid" ]]; then
+    return
+  fi
+
+  for sig in TERM KILL; do
+    if sudo kill -0 "$pqos_pid" 2>/dev/null; then
+      sudo kill -s "$sig" "$pqos_pid" 2>/dev/null || true
+      for _ in {1..50}; do
+        if ! sudo kill -0 "$pqos_pid" 2>/dev/null; then
+          break
+        fi
+        sleep 0.2
+      done
+    fi
+  done
+}
+
 ################################################################################
 ### 1. Create results directory and placeholder logs
 ################################################################################
@@ -591,6 +687,11 @@ if $run_pcm_power; then
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
+  reset_pqos_state
+  pqos_pid=""
+  pqos_output="/local/data/results/id_13_pqos_pid.txt"
+  pqos_pattern="/local/tools/matlab/bin/matlab -nodisplay -nosplash"
+
   sudo -E bash -lc '
     taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
@@ -603,7 +704,30 @@ if $run_pcm_power; then
         taskset -c 6 /local/tools/matlab/bin/matlab -nodisplay -nosplash \
           -r \"cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;\"
       "
-  ' >> /local/data/results/id_13_pcm_power.log 2>&1
+  ' >> /local/data/results/id_13_pcm_power.log 2>&1 &
+  pcm_power_job_pid=$!
+
+  if mapfile -t pqos_targets < <(await_workload_pids "$pqos_pattern" "$pcm_power_job_pid"); then
+    echo "pqos monitoring workload PID(s): ${pqos_targets[*]}"
+    if pqos_pid=$(start_pqos_monitor "$pqos_output" "${pqos_targets[@]}"); then
+      echo "pqos started with PID $pqos_pid"
+    else
+      echo "Warning: failed to start pqos for PID(s): ${pqos_targets[*]}" >&2
+      pqos_pid=""
+    fi
+  else
+    echo "Warning: unable to discover workload PID(s) for pqos (pattern: $pqos_pattern)" >&2
+  fi
+
+  pcm_power_status=0
+  if ! wait "$pcm_power_job_pid"; then
+    pcm_power_status=$?
+  fi
+  stop_pqos_monitor "$pqos_pid"
+  if (( pcm_power_status != 0 )); then
+    exit "$pcm_power_status"
+  fi
+
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -336,6 +336,102 @@ idle_wait() {
   echo
 }
 
+PCM_POWER_SAMPLE_INTERVAL="0.5"
+PQOS_BIN="/usr/bin/pqos"
+PQOS_MONITOR_DURATION=86400
+PQOS_DISCOVERY_TIMEOUT=30
+PQOS_DISCOVERY_INTERVAL=0.2
+
+reset_pqos_state() {
+  sudo "$PQOS_BIN" -R >/dev/null 2>&1 || true
+}
+
+await_workload_pids() {
+  local pattern="$1"
+  local monitor_pid="${2:-}"
+  local timeout="${3:-$PQOS_DISCOVERY_TIMEOUT}"
+  local interval="${4:-$PQOS_DISCOVERY_INTERVAL}"
+  local start_time=$SECONDS
+  local -a pids=()
+
+  while (( SECONDS - start_time < timeout )); do
+    mapfile -t pids < <(pgrep -f -- "$pattern" || true)
+    if (( ${#pids[@]} )); then
+      printf '%s\n' "${pids[@]}"
+      return 0
+    fi
+    if [[ -n "$monitor_pid" ]] && ! kill -0 "$monitor_pid" 2>/dev/null; then
+      break
+    fi
+    sleep "$interval"
+  done
+  return 1
+}
+
+start_pqos_monitor() {
+  local output_file="$1"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 1
+  fi
+
+  local -a monitor_spec_parts=()
+  local pid
+  for pid in "$@"; do
+    monitor_spec_parts+=("pid:$pid")
+  done
+
+  local monitor_spec
+  monitor_spec=$(IFS=';'; echo "${monitor_spec_parts[*]}")
+  local pqos_pid_file
+  pqos_pid_file=$(mktemp)
+
+  if ! sudo env PQOS_BIN="$PQOS_BIN" MONITOR_SPEC="$monitor_spec" PQOS_OUTPUT="$output_file" \
+    PQOS_PID_FILE="$pqos_pid_file" PQOS_INTERVAL="$PCM_POWER_SAMPLE_INTERVAL" \
+    PQOS_DURATION="$PQOS_MONITOR_DURATION" bash -lc '
+      set -e
+      nohup "$PQOS_BIN" -I -u text -m "$MONITOR_SPEC" -i "$PQOS_INTERVAL" -t "$PQOS_DURATION" \
+        > "$PQOS_OUTPUT" 2>&1 &
+      echo $! > "$PQOS_PID_FILE"
+      disown || true
+    '; then
+    rm -f "$pqos_pid_file"
+    return 1
+  fi
+
+  local pqos_pid=""
+  if [[ -f "$pqos_pid_file" ]]; then
+    read -r pqos_pid < "$pqos_pid_file" || true
+    rm -f "$pqos_pid_file"
+  fi
+
+  if [[ -z "$pqos_pid" ]]; then
+    return 1
+  fi
+
+  echo "$pqos_pid"
+  return 0
+}
+
+stop_pqos_monitor() {
+  local pqos_pid="$1"
+  if [[ -z "$pqos_pid" ]]; then
+    return
+  fi
+
+  for sig in TERM KILL; do
+    if sudo kill -0 "$pqos_pid" 2>/dev/null; then
+      sudo kill -s "$sig" "$pqos_pid" 2>/dev/null || true
+      for _ in {1..50}; do
+        if ! sudo kill -0 "$pqos_pid" 2>/dev/null; then
+          break
+        fi
+        sleep 0.2
+      done
+    fi
+  done
+}
+
 ################################################################################
 ### 1. Create results directory and placeholder logs
 ################################################################################
@@ -606,6 +702,11 @@ if $run_pcm_power; then
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
+  reset_pqos_state
+  pqos_pid=""
+  pqos_output="/local/data/results/id_20_3gram_llm_pqos_pid.txt"
+  pqos_pattern="python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py"
+
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -623,7 +724,30 @@ if $run_pcm_power; then
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
           --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
       "
-  ' >>/local/data/results/id_20_3gram_llm_pcm_power.log 2>&1
+  ' >>/local/data/results/id_20_3gram_llm_pcm_power.log 2>&1 &
+  pcm_power_job_pid=$!
+
+  if mapfile -t pqos_targets < <(await_workload_pids "$pqos_pattern" "$pcm_power_job_pid"); then
+    echo "pqos monitoring workload PID(s): ${pqos_targets[*]}"
+    if pqos_pid=$(start_pqos_monitor "$pqos_output" "${pqos_targets[@]}"); then
+      echo "pqos started with PID $pqos_pid"
+    else
+      echo "Warning: failed to start pqos for PID(s): ${pqos_targets[*]}" >&2
+      pqos_pid=""
+    fi
+  else
+    echo "Warning: unable to discover workload PID(s) for pqos (pattern: $pqos_pattern)" >&2
+  fi
+
+  pcm_power_status=0
+  if ! wait "$pcm_power_job_pid"; then
+    pcm_power_status=$?
+  fi
+  stop_pqos_monitor "$pqos_pid"
+  if (( pcm_power_status != 0 )); then
+    exit "$pcm_power_status"
+  fi
+
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -336,6 +336,102 @@ idle_wait() {
   echo
 }
 
+PCM_POWER_SAMPLE_INTERVAL="0.5"
+PQOS_BIN="/usr/bin/pqos"
+PQOS_MONITOR_DURATION=86400
+PQOS_DISCOVERY_TIMEOUT=30
+PQOS_DISCOVERY_INTERVAL=0.2
+
+reset_pqos_state() {
+  sudo "$PQOS_BIN" -R >/dev/null 2>&1 || true
+}
+
+await_workload_pids() {
+  local pattern="$1"
+  local monitor_pid="${2:-}"
+  local timeout="${3:-$PQOS_DISCOVERY_TIMEOUT}"
+  local interval="${4:-$PQOS_DISCOVERY_INTERVAL}"
+  local start_time=$SECONDS
+  local -a pids=()
+
+  while (( SECONDS - start_time < timeout )); do
+    mapfile -t pids < <(pgrep -f -- "$pattern" || true)
+    if (( ${#pids[@]} )); then
+      printf '%s\n' "${pids[@]}"
+      return 0
+    fi
+    if [[ -n "$monitor_pid" ]] && ! kill -0 "$monitor_pid" 2>/dev/null; then
+      break
+    fi
+    sleep "$interval"
+  done
+  return 1
+}
+
+start_pqos_monitor() {
+  local output_file="$1"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 1
+  fi
+
+  local -a monitor_spec_parts=()
+  local pid
+  for pid in "$@"; do
+    monitor_spec_parts+=("pid:$pid")
+  done
+
+  local monitor_spec
+  monitor_spec=$(IFS=';'; echo "${monitor_spec_parts[*]}")
+  local pqos_pid_file
+  pqos_pid_file=$(mktemp)
+
+  if ! sudo env PQOS_BIN="$PQOS_BIN" MONITOR_SPEC="$monitor_spec" PQOS_OUTPUT="$output_file" \
+    PQOS_PID_FILE="$pqos_pid_file" PQOS_INTERVAL="$PCM_POWER_SAMPLE_INTERVAL" \
+    PQOS_DURATION="$PQOS_MONITOR_DURATION" bash -lc '
+      set -e
+      nohup "$PQOS_BIN" -I -u text -m "$MONITOR_SPEC" -i "$PQOS_INTERVAL" -t "$PQOS_DURATION" \
+        > "$PQOS_OUTPUT" 2>&1 &
+      echo $! > "$PQOS_PID_FILE"
+      disown || true
+    '; then
+    rm -f "$pqos_pid_file"
+    return 1
+  fi
+
+  local pqos_pid=""
+  if [[ -f "$pqos_pid_file" ]]; then
+    read -r pqos_pid < "$pqos_pid_file" || true
+    rm -f "$pqos_pid_file"
+  fi
+
+  if [[ -z "$pqos_pid" ]]; then
+    return 1
+  fi
+
+  echo "$pqos_pid"
+  return 0
+}
+
+stop_pqos_monitor() {
+  local pqos_pid="$1"
+  if [[ -z "$pqos_pid" ]]; then
+    return
+  fi
+
+  for sig in TERM KILL; do
+    if sudo kill -0 "$pqos_pid" 2>/dev/null; then
+      sudo kill -s "$sig" "$pqos_pid" 2>/dev/null || true
+      for _ in {1..50}; do
+        if ! sudo kill -0 "$pqos_pid" 2>/dev/null; then
+          break
+        fi
+        sleep 0.2
+      done
+    fi
+  done
+}
+
 ################################################################################
 ### 1. Create results directory and placeholder logs
 ################################################################################
@@ -606,6 +702,11 @@ if $run_pcm_power; then
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
+  reset_pqos_state
+  pqos_pid=""
+  pqos_output="/local/data/results/id_20_3gram_lm_pqos_pid.txt"
+  pqos_pattern="python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py"
+
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -623,7 +724,30 @@ if $run_pcm_power; then
           --lmDir=/local/data/languageModel/ \
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
       "
-  ' >>/local/data/results/id_20_3gram_lm_pcm_power.log 2>&1
+  ' >>/local/data/results/id_20_3gram_lm_pcm_power.log 2>&1 &
+  pcm_power_job_pid=$!
+
+  if mapfile -t pqos_targets < <(await_workload_pids "$pqos_pattern" "$pcm_power_job_pid"); then
+    echo "pqos monitoring workload PID(s): ${pqos_targets[*]}"
+    if pqos_pid=$(start_pqos_monitor "$pqos_output" "${pqos_targets[@]}"); then
+      echo "pqos started with PID $pqos_pid"
+    else
+      echo "Warning: failed to start pqos for PID(s): ${pqos_targets[*]}" >&2
+      pqos_pid=""
+    fi
+  else
+    echo "Warning: unable to discover workload PID(s) for pqos (pattern: $pqos_pattern)" >&2
+  fi
+
+  pcm_power_status=0
+  if ! wait "$pcm_power_job_pid"; then
+    pcm_power_status=$?
+  fi
+  stop_pqos_monitor "$pqos_pid"
+  if (( pcm_power_status != 0 )); then
+    exit "$pcm_power_status"
+  fi
+
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -336,6 +336,102 @@ idle_wait() {
   echo
 }
 
+PCM_POWER_SAMPLE_INTERVAL="0.5"
+PQOS_BIN="/usr/bin/pqos"
+PQOS_MONITOR_DURATION=86400
+PQOS_DISCOVERY_TIMEOUT=30
+PQOS_DISCOVERY_INTERVAL=0.2
+
+reset_pqos_state() {
+  sudo "$PQOS_BIN" -R >/dev/null 2>&1 || true
+}
+
+await_workload_pids() {
+  local pattern="$1"
+  local monitor_pid="${2:-}"
+  local timeout="${3:-$PQOS_DISCOVERY_TIMEOUT}"
+  local interval="${4:-$PQOS_DISCOVERY_INTERVAL}"
+  local start_time=$SECONDS
+  local -a pids=()
+
+  while (( SECONDS - start_time < timeout )); do
+    mapfile -t pids < <(pgrep -f -- "$pattern" || true)
+    if (( ${#pids[@]} )); then
+      printf '%s\n' "${pids[@]}"
+      return 0
+    fi
+    if [[ -n "$monitor_pid" ]] && ! kill -0 "$monitor_pid" 2>/dev/null; then
+      break
+    fi
+    sleep "$interval"
+  done
+  return 1
+}
+
+start_pqos_monitor() {
+  local output_file="$1"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 1
+  fi
+
+  local -a monitor_spec_parts=()
+  local pid
+  for pid in "$@"; do
+    monitor_spec_parts+=("pid:$pid")
+  done
+
+  local monitor_spec
+  monitor_spec=$(IFS=';'; echo "${monitor_spec_parts[*]}")
+  local pqos_pid_file
+  pqos_pid_file=$(mktemp)
+
+  if ! sudo env PQOS_BIN="$PQOS_BIN" MONITOR_SPEC="$monitor_spec" PQOS_OUTPUT="$output_file" \
+    PQOS_PID_FILE="$pqos_pid_file" PQOS_INTERVAL="$PCM_POWER_SAMPLE_INTERVAL" \
+    PQOS_DURATION="$PQOS_MONITOR_DURATION" bash -lc '
+      set -e
+      nohup "$PQOS_BIN" -I -u text -m "$MONITOR_SPEC" -i "$PQOS_INTERVAL" -t "$PQOS_DURATION" \
+        > "$PQOS_OUTPUT" 2>&1 &
+      echo $! > "$PQOS_PID_FILE"
+      disown || true
+    '; then
+    rm -f "$pqos_pid_file"
+    return 1
+  fi
+
+  local pqos_pid=""
+  if [[ -f "$pqos_pid_file" ]]; then
+    read -r pqos_pid < "$pqos_pid_file" || true
+    rm -f "$pqos_pid_file"
+  fi
+
+  if [[ -z "$pqos_pid" ]]; then
+    return 1
+  fi
+
+  echo "$pqos_pid"
+  return 0
+}
+
+stop_pqos_monitor() {
+  local pqos_pid="$1"
+  if [[ -z "$pqos_pid" ]]; then
+    return
+  fi
+
+  for sig in TERM KILL; do
+    if sudo kill -0 "$pqos_pid" 2>/dev/null; then
+      sudo kill -s "$sig" "$pqos_pid" 2>/dev/null || true
+      for _ in {1..50}; do
+        if ! sudo kill -0 "$pqos_pid" 2>/dev/null; then
+          break
+        fi
+        sleep 0.2
+      done
+    fi
+  done
+}
+
 ################################################################################
 ### 1. Create results directory and placeholder logs
 ################################################################################
@@ -606,6 +702,11 @@ if $run_pcm_power; then
   idle_wait
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
+  reset_pqos_state
+  pqos_pid=""
+  pqos_output="/local/data/results/id_20_3gram_rnn_pqos_pid.txt"
+  pqos_pattern="python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py"
+
   sudo -E bash -lc '
     source /local/tools/bci_env/bin/activate
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
@@ -623,7 +724,30 @@ if $run_pcm_power; then
           --datasetPath=/local/data/ptDecoder_ctc \
           --modelPath=/local/data/speechBaseline4/
       "
-  ' >>/local/data/results/id_20_3gram_rnn_pcm_power.log 2>&1
+  ' >>/local/data/results/id_20_3gram_rnn_pcm_power.log 2>&1 &
+  pcm_power_job_pid=$!
+
+  if mapfile -t pqos_targets < <(await_workload_pids "$pqos_pattern" "$pcm_power_job_pid"); then
+    echo "pqos monitoring workload PID(s): ${pqos_targets[*]}"
+    if pqos_pid=$(start_pqos_monitor "$pqos_output" "${pqos_targets[@]}"); then
+      echo "pqos started with PID $pqos_pid"
+    else
+      echo "Warning: failed to start pqos for PID(s): ${pqos_targets[*]}" >&2
+      pqos_pid=""
+    fi
+  else
+    echo "Warning: unable to discover workload PID(s) for pqos (pattern: $pqos_pattern)" >&2
+  fi
+
+  pcm_power_status=0
+  if ! wait "$pcm_power_job_pid"; then
+    pcm_power_status=$?
+  fi
+  stop_pqos_monitor "$pqos_pid"
+  if (( pcm_power_status != 0 )); then
+    exit "$pcm_power_status"
+  fi
+
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cpuset cmake
+# Ensure pqos and matching kernel tools are available.
+sudo apt-get install -y intel-cmt-cat linux-tools-common linux-tools-$(uname -r)
 
 ################################################################################
 

--- a/scripts/startup_1.sh
+++ b/scripts/startup_1.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cpuset cmake
+# Ensure pqos and matching kernel tools are available.
+sudo apt-get install -y intel-cmt-cat linux-tools-common linux-tools-$(uname -r)
 
 ################################################################################
 

--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -284,6 +284,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential ppp pptp-linux cpuset cmake
+# Ensure pqos and matching kernel tools are available.
+sudo apt-get install -y intel-cmt-cat linux-tools-common linux-tools-$(uname -r)
 
 ################################################################################
 

--- a/scripts/startup_20_3gram.sh
+++ b/scripts/startup_20_3gram.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cmake
+# Ensure pqos and matching kernel tools are available.
+sudo apt-get install -y intel-cmt-cat linux-tools-common linux-tools-$(uname -r)
 # Install necessary packages
 sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
 

--- a/scripts/startup_3.sh
+++ b/scripts/startup_3.sh
@@ -143,6 +143,8 @@ echo "========================="
 sudo apt-get update
 # Install essential packages: git and build-essential.
 sudo apt-get install -y git build-essential cpuset cmake
+# Ensure pqos and matching kernel tools are available.
+sudo apt-get install -y intel-cmt-cat linux-tools-common linux-tools-$(uname -r)
 
 ################################################################################
 


### PR DESCRIPTION
## Summary
- add pqos helper functions and instrumentation across the pcm-power sections in the workload run scripts so PID MBM is sampled alongside power data
- detect workload processes, launch pqos with the same sampling interval, and terminate it cleanly once pcm-power completes
- ensure the startup scripts install intel-cmt-cat and matching linux-tools packages required for pqos

## Testing
- bash -n scripts/run_1.sh
- bash -n scripts/run_3.sh
- bash -n scripts/run_13.sh
- bash -n scripts/run_20_3gram_lm.sh
- bash -n scripts/run_20_3gram_llm.sh
- bash -n scripts/run_20_3gram_rnn.sh
- bash -n scripts/startup.sh
- bash -n scripts/startup_1.sh
- bash -n scripts/startup_3.sh
- bash -n scripts/startup_13.sh
- bash -n scripts/startup_20_3gram.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1b5aad8ac832c842a0901ab1f6a68