### PR TITLE
Install intel-cmt-cat in startup scripts

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cpuset cmake
+sudo apt-get install -y git build-essential cpuset cmake intel-cmt-cat
 
 ################################################################################
 

--- a/scripts/startup_1.sh
+++ b/scripts/startup_1.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cpuset cmake
+sudo apt-get install -y git build-essential cpuset cmake intel-cmt-cat
 
 ################################################################################
 

--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -283,7 +283,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential ppp pptp-linux cpuset cmake
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential ppp pptp-linux cpuset cmake intel-cmt-cat
 
 ################################################################################
 

--- a/scripts/startup_20_3gram.sh
+++ b/scripts/startup_20_3gram.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cmake
+sudo apt-get install -y git build-essential cmake intel-cmt-cat
 # Install necessary packages
 sudo apt-get install -y zlib1g-dev automake autoconf cmake sox gfortran libtool protobuf-compiler python3.10 python2.7 pip  python3.10-venv curl g++ graphviz libatlas3-base libtool pkg-config subversion unzip wget cpuset
 

--- a/scripts/startup_3.sh
+++ b/scripts/startup_3.sh
@@ -142,7 +142,7 @@ echo "========================="
 # Update the package lists.
 sudo apt-get update
 # Install essential packages: git and build-essential.
-sudo apt-get install -y git build-essential cpuset cmake
+sudo apt-get install -y git build-essential cpuset cmake intel-cmt-cat
 
 ################################################################################
 


### PR DESCRIPTION
## Summary
- add intel-cmt-cat to the base package installation list in each startup script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d57af4092c832c8b44d5d7c058160e