### PR TITLE
Add power attribution sidecars to run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -87,6 +87,24 @@ log_debug() {
     printf '[DEBUG] %s\n' "$*"
   fi
 }
+
+PQOS_PID=""
+TURBOSTAT_PID=""
+
+stop_attribution_sidecars() {
+  if [[ -n ${PQOS_PID:-} ]]; then
+    log_debug "Stopping pqos sidecar (PID ${PQOS_PID})"
+    kill -TERM "$PQOS_PID" 2>/dev/null || true
+    wait "$PQOS_PID" 2>/dev/null || true
+    PQOS_PID=""
+  fi
+  if [[ -n ${TURBOSTAT_PID:-} ]]; then
+    log_debug "Stopping turbostat sidecar (PID ${TURBOSTAT_PID})"
+    kill -TERM "$TURBOSTAT_PID" 2>/dev/null || true
+    wait "$TURBOSTAT_PID" 2>/dev/null || true
+    TURBOSTAT_PID=""
+  fi
+}
 turbo_state="${TURBO_STATE:-off}"
 pkg_cap_w="${PKG_W:-15}"
 dram_cap_w="${DRAM_W:-5}"
@@ -229,6 +247,68 @@ if $debug_enabled; then
   log_debug "  effective user: ${effective_user} (uid=${UID})"
   log_debug "  effective group: ${effective_group} (gid=${effective_gid})"
 fi
+
+WORKLOAD_CPU=${WORKLOAD_CPU:-6}
+PCM_CPU=${PCM_CPU:-5}
+TOOLS_CPU=${TOOLS_CPU:-1}
+OUTDIR=${OUTDIR:-/local/data/results}
+IDTAG=${IDTAG:-id_1}
+TS_INTERVAL=${TS_INTERVAL:-0.5}
+PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
+mkdir -p "$OUTDIR"
+
+ONLINE_MASK="$(cat /sys/devices/system/cpu/online)"
+OTHERS="$(awk -v excl="$WORKLOAD_CPU" '
+  function emit(a,b){
+    for(i=a;i<=b;i++) {
+      if(i!=excl) {
+        out = out (out? ",":"") i
+      }
+    }
+  }
+  BEGIN {
+    while((getline<"/sys/devices/system/cpu/online")>0){
+      n=split($0,a,",");
+      for(k=1;k<=n;k++){
+        if(a[k]~/-/){
+          split(a[k],r,"-");
+          emit(r[1],r[2])
+        } else {
+          emit(a[k],a[k])
+        }
+      }
+    }
+    print out
+  }
+')"
+
+if [[ "$TOOLS_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$PCM_CPU" ]]; then
+      TOOLS_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ "$PCM_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$TOOLS_CPU" ]]; then
+      PCM_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+log_debug "Attribution config:"
+log_debug "  WORKLOAD_CPU=${WORKLOAD_CPU}, PCM_CPU=${PCM_CPU}, TOOLS_CPU=${TOOLS_CPU}"
+log_debug "  ONLINE_MASK=${ONLINE_MASK}"
+log_debug "  OTHERS=${OTHERS}"
+log_debug "  OUTDIR=${OUTDIR}, IDTAG=${IDTAG}, intervals: pqos=${PQOS_INTERVAL_TICKS}*100ms, turbostat=${TS_INTERVAL}s"
 
 turbo_state="${turbo_state,,}"
 case "$turbo_state" in
@@ -659,16 +739,41 @@ if $run_pcm_power; then
   echo "----------------------------"
   echo "PCM-POWER"
   echo "----------------------------"
-  log_debug "Launching pcm-power (CSV=/local/data/results/id_1_pcm_power.csv, log=/local/data/results/id_1_pcm_power.log, profiler CPU=5, workload CPU=6)"
+  log_debug "Launching pcm-power (CSV=${OUTDIR}/${IDTAG}_pcm_power.csv, log=${OUTDIR}/${IDTAG}_pcm_power.log, profiler CPU=${PCM_CPU}, workload CPU=${WORKLOAD_CPU})"
   idle_wait
+
+  pqos_groups="mbt:[${WORKLOAD_CPU}]"
+  if [[ -n "${OTHERS}" ]]; then
+    pqos_groups+=";mbt:[${OTHERS}]"
+  fi
+
+  PQOS_CMD="taskset -c ${TOOLS_CPU} pqos -I -u csv -o ${OUTDIR}/${IDTAG}_pqos.csv -i ${PQOS_INTERVAL_TICKS} -m '${pqos_groups}'"
+  trap 'stop_attribution_sidecars' EXIT INT TERM
+  log_debug "Starting pqos sidecar with: ${PQOS_CMD}"
+  sudo nohup bash -lc "exec ${PQOS_CMD}" >/local/logs/pqos.log 2>&1 &
+  PQOS_PID=$!
+  log_debug "pqos PID=${PQOS_PID}, output=${OUTDIR}/${IDTAG}_pqos.csv, log=/local/logs/pqos.log"
+  sleep 1
+  log_debug "pqos csv header (first 2 lines):"
+  head -n 2 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+
+  TSTAT_CMD="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
+  log_debug "Starting turbostat sidecar with: ${TSTAT_CMD}"
+  sudo -E bash -lc "exec ${TSTAT_CMD}" &
+  TURBOSTAT_PID=$!
+  log_debug "turbostat PID=${TURBOSTAT_PID}, out(txt)=${OUTDIR}/${IDTAG}_turbostat.txt"
+  sleep 1
+  log_debug "turbostat first 6 lines:"
+  head -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo sh -c '
-    taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
+    taskset -c '"${PCM_CPU}"' /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
-      -csv=/local/data/results/id_1_pcm_power.csv -- \
-      taskset -c 6 /local/bci_code/id_1/main \
-    >>/local/data/results/id_1_pcm_power.log 2>&1
+      -csv='"${OUTDIR}/${IDTAG}_pcm_power.csv"' -- \
+      taskset -c '"${WORKLOAD_CPU}"' /local/bci_code/id_1/main \
+    >>'"${OUTDIR}/${IDTAG}_pcm_power.log"' 2>&1
   '
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
@@ -676,6 +781,21 @@ if $run_pcm_power; then
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
   log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  stop_attribution_sidecars
+  trap - EXIT INT TERM
+  log_debug "pqos last 3 lines:"
+  tail -n 3 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+  log_debug "turbostat last 6 lines:"
+  tail -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+  if [[ -f "${OUTDIR}/${IDTAG}_turbostat.txt" ]]; then
+    awk 'BEGIN{OFS=","}
+         $1=="Time_Of_Day_Seconds"{next}
+         $2=="-"{next}
+         NF>0 {gsub(/[[:space:]]+/,","); print}
+    ' "${OUTDIR}/${IDTAG}_turbostat.txt" > "${OUTDIR}/${IDTAG}_turbostat.csv"
+    log_debug "turbostat CSV (first 6 lines):"
+    head -n 6 "${OUTDIR}/${IDTAG}_turbostat.csv" 2>/dev/null || true
+  fi
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -87,6 +87,24 @@ log_debug() {
     printf '[DEBUG] %s\n' "$*"
   fi
 }
+
+PQOS_PID=""
+TURBOSTAT_PID=""
+
+stop_attribution_sidecars() {
+  if [[ -n ${PQOS_PID:-} ]]; then
+    log_debug "Stopping pqos sidecar (PID ${PQOS_PID})"
+    kill -TERM "$PQOS_PID" 2>/dev/null || true
+    wait "$PQOS_PID" 2>/dev/null || true
+    PQOS_PID=""
+  fi
+  if [[ -n ${TURBOSTAT_PID:-} ]]; then
+    log_debug "Stopping turbostat sidecar (PID ${TURBOSTAT_PID})"
+    kill -TERM "$TURBOSTAT_PID" 2>/dev/null || true
+    wait "$TURBOSTAT_PID" 2>/dev/null || true
+    TURBOSTAT_PID=""
+  fi
+}
 turbo_state="${TURBO_STATE:-off}"
 pkg_cap_w="${PKG_W:-15}"
 dram_cap_w="${DRAM_W:-5}"
@@ -229,6 +247,68 @@ if $debug_enabled; then
   log_debug "  effective user: ${effective_user} (uid=${UID})"
   log_debug "  effective group: ${effective_group} (gid=${effective_gid})"
 fi
+
+WORKLOAD_CPU=${WORKLOAD_CPU:-6}
+PCM_CPU=${PCM_CPU:-5}
+TOOLS_CPU=${TOOLS_CPU:-1}
+OUTDIR=${OUTDIR:-/local/data/results}
+IDTAG=${IDTAG:-id_20_3gram_llm}
+TS_INTERVAL=${TS_INTERVAL:-0.5}
+PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
+mkdir -p "$OUTDIR"
+
+ONLINE_MASK="$(cat /sys/devices/system/cpu/online)"
+OTHERS="$(awk -v excl="$WORKLOAD_CPU" '
+  function emit(a,b){
+    for(i=a;i<=b;i++) {
+      if(i!=excl) {
+        out = out (out? ",":"") i
+      }
+    }
+  }
+  BEGIN {
+    while((getline<"/sys/devices/system/cpu/online")>0){
+      n=split($0,a,",");
+      for(k=1;k<=n;k++){
+        if(a[k]~/-/){
+          split(a[k],r,"-");
+          emit(r[1],r[2])
+        } else {
+          emit(a[k],a[k])
+        }
+      }
+    }
+    print out
+  }
+')"
+
+if [[ "$TOOLS_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$PCM_CPU" ]]; then
+      TOOLS_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ "$PCM_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$TOOLS_CPU" ]]; then
+      PCM_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+log_debug "Attribution config:"
+log_debug "  WORKLOAD_CPU=${WORKLOAD_CPU}, PCM_CPU=${PCM_CPU}, TOOLS_CPU=${TOOLS_CPU}"
+log_debug "  ONLINE_MASK=${ONLINE_MASK}"
+log_debug "  OTHERS=${OTHERS}"
+log_debug "  OUTDIR=${OUTDIR}, IDTAG=${IDTAG}, intervals: pqos=${PQOS_INTERVAL_TICKS}*100ms, turbostat=${TS_INTERVAL}s"
 
 turbo_state="${turbo_state,,}"
 case "$turbo_state" in
@@ -692,8 +772,33 @@ if $run_pcm_power; then
   echo "----------------------------"
   echo "PCM-POWER"
   echo "----------------------------"
-  log_debug "Launching pcm-power (CSV=/local/data/results/id_20_3gram_llm_pcm_power.csv, log=/local/data/results/id_20_3gram_llm_pcm_power.log, profiler CPU=5, workload CPU=6)"
+  log_debug "Launching pcm-power (CSV=${OUTDIR}/${IDTAG}_pcm_power.csv, log=${OUTDIR}/${IDTAG}_pcm_power.log, profiler CPU=${PCM_CPU}, workload CPU=${WORKLOAD_CPU})"
   idle_wait
+
+  pqos_groups="mbt:[${WORKLOAD_CPU}]"
+  if [[ -n "${OTHERS}" ]]; then
+    pqos_groups+=";mbt:[${OTHERS}]"
+  fi
+
+  PQOS_CMD="taskset -c ${TOOLS_CPU} pqos -I -u csv -o ${OUTDIR}/${IDTAG}_pqos.csv -i ${PQOS_INTERVAL_TICKS} -m '${pqos_groups}'"
+  trap 'stop_attribution_sidecars' EXIT INT TERM
+  log_debug "Starting pqos sidecar with: ${PQOS_CMD}"
+  sudo nohup bash -lc "exec ${PQOS_CMD}" >/local/logs/pqos.log 2>&1 &
+  PQOS_PID=$!
+  log_debug "pqos PID=${PQOS_PID}, output=${OUTDIR}/${IDTAG}_pqos.csv, log=/local/logs/pqos.log"
+  sleep 1
+  log_debug "pqos csv header (first 2 lines):"
+  head -n 2 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+
+  TSTAT_CMD="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
+  log_debug "Starting turbostat sidecar with: ${TSTAT_CMD}"
+  sudo -E bash -lc "exec ${TSTAT_CMD}" &
+  TURBOSTAT_PID=$!
+  log_debug "turbostat PID=${TURBOSTAT_PID}, out(txt)=${OUTDIR}/${IDTAG}_turbostat.txt"
+  sleep 1
+  log_debug "turbostat first 6 lines:"
+  head -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -702,24 +807,39 @@ if $run_pcm_power; then
     . path.sh
     export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-    taskset -c 6 /local/tools/pcm/build/bin/pcm-power 0.5 \
+    taskset -c '"${PCM_CPU}"' /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
-      -csv=/local/data/results/id_20_3gram_llm_pcm_power.csv -- \
+      -csv='"${OUTDIR}/${IDTAG}_pcm_power.csv"' -- \
       bash -lc "
         source /local/tools/bci_env/bin/activate
         . path.sh
         export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+        taskset -c '"${WORKLOAD_CPU}"' python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
           --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl
       "
-  ' >>/local/data/results/id_20_3gram_llm_pcm_power.log 2>&1
+  ' >>'"${OUTDIR}/${IDTAG}_pcm_power.log"' 2>&1
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_llm_pcm_power.log
   log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  stop_attribution_sidecars
+  trap - EXIT INT TERM
+  log_debug "pqos last 3 lines:"
+  tail -n 3 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+  log_debug "turbostat last 6 lines:"
+  tail -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+  if [[ -f "${OUTDIR}/${IDTAG}_turbostat.txt" ]]; then
+    awk 'BEGIN{OFS=","}
+         $1=="Time_Of_Day_Seconds"{next}
+         $2=="-"{next}
+         NF>0 {gsub(/[[:space:]]+/,","); print}
+    ' "${OUTDIR}/${IDTAG}_turbostat.txt" > "${OUTDIR}/${IDTAG}_turbostat.csv"
+    log_debug "turbostat CSV (first 6 lines):"
+    head -n 6 "${OUTDIR}/${IDTAG}_turbostat.csv" 2>/dev/null || true
+  fi
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -87,6 +87,24 @@ log_debug() {
     printf '[DEBUG] %s\n' "$*"
   fi
 }
+
+PQOS_PID=""
+TURBOSTAT_PID=""
+
+stop_attribution_sidecars() {
+  if [[ -n ${PQOS_PID:-} ]]; then
+    log_debug "Stopping pqos sidecar (PID ${PQOS_PID})"
+    kill -TERM "$PQOS_PID" 2>/dev/null || true
+    wait "$PQOS_PID" 2>/dev/null || true
+    PQOS_PID=""
+  fi
+  if [[ -n ${TURBOSTAT_PID:-} ]]; then
+    log_debug "Stopping turbostat sidecar (PID ${TURBOSTAT_PID})"
+    kill -TERM "$TURBOSTAT_PID" 2>/dev/null || true
+    wait "$TURBOSTAT_PID" 2>/dev/null || true
+    TURBOSTAT_PID=""
+  fi
+}
 turbo_state="${TURBO_STATE:-off}"
 pkg_cap_w="${PKG_W:-15}"
 dram_cap_w="${DRAM_W:-5}"
@@ -229,6 +247,68 @@ if $debug_enabled; then
   log_debug "  effective user: ${effective_user} (uid=${UID})"
   log_debug "  effective group: ${effective_group} (gid=${effective_gid})"
 fi
+
+WORKLOAD_CPU=${WORKLOAD_CPU:-6}
+PCM_CPU=${PCM_CPU:-5}
+TOOLS_CPU=${TOOLS_CPU:-1}
+OUTDIR=${OUTDIR:-/local/data/results}
+IDTAG=${IDTAG:-id_20_3gram_lm}
+TS_INTERVAL=${TS_INTERVAL:-0.5}
+PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
+mkdir -p "$OUTDIR"
+
+ONLINE_MASK="$(cat /sys/devices/system/cpu/online)"
+OTHERS="$(awk -v excl="$WORKLOAD_CPU" '
+  function emit(a,b){
+    for(i=a;i<=b;i++) {
+      if(i!=excl) {
+        out = out (out? ",":"") i
+      }
+    }
+  }
+  BEGIN {
+    while((getline<"/sys/devices/system/cpu/online")>0){
+      n=split($0,a,",");
+      for(k=1;k<=n;k++){
+        if(a[k]~/-/){
+          split(a[k],r,"-");
+          emit(r[1],r[2])
+        } else {
+          emit(a[k],a[k])
+        }
+      }
+    }
+    print out
+  }
+')"
+
+if [[ "$TOOLS_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$PCM_CPU" ]]; then
+      TOOLS_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ "$PCM_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$TOOLS_CPU" ]]; then
+      PCM_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+log_debug "Attribution config:"
+log_debug "  WORKLOAD_CPU=${WORKLOAD_CPU}, PCM_CPU=${PCM_CPU}, TOOLS_CPU=${TOOLS_CPU}"
+log_debug "  ONLINE_MASK=${ONLINE_MASK}"
+log_debug "  OTHERS=${OTHERS}"
+log_debug "  OUTDIR=${OUTDIR}, IDTAG=${IDTAG}, intervals: pqos=${PQOS_INTERVAL_TICKS}*100ms, turbostat=${TS_INTERVAL}s"
 
 turbo_state="${turbo_state,,}"
 case "$turbo_state" in
@@ -692,8 +772,33 @@ if $run_pcm_power; then
   echo "----------------------------"
   echo "PCM-POWER"
   echo "----------------------------"
-  log_debug "Launching pcm-power (CSV=/local/data/results/id_20_3gram_lm_pcm_power.csv, log=/local/data/results/id_20_3gram_lm_pcm_power.log, profiler CPU=5, workload CPU=6)"
+  log_debug "Launching pcm-power (CSV=${OUTDIR}/${IDTAG}_pcm_power.csv, log=${OUTDIR}/${IDTAG}_pcm_power.log, profiler CPU=${PCM_CPU}, workload CPU=${WORKLOAD_CPU})"
   idle_wait
+
+  pqos_groups="mbt:[${WORKLOAD_CPU}]"
+  if [[ -n "${OTHERS}" ]]; then
+    pqos_groups+=";mbt:[${OTHERS}]"
+  fi
+
+  PQOS_CMD="taskset -c ${TOOLS_CPU} pqos -I -u csv -o ${OUTDIR}/${IDTAG}_pqos.csv -i ${PQOS_INTERVAL_TICKS} -m '${pqos_groups}'"
+  trap 'stop_attribution_sidecars' EXIT INT TERM
+  log_debug "Starting pqos sidecar with: ${PQOS_CMD}"
+  sudo nohup bash -lc "exec ${PQOS_CMD}" >/local/logs/pqos.log 2>&1 &
+  PQOS_PID=$!
+  log_debug "pqos PID=${PQOS_PID}, output=${OUTDIR}/${IDTAG}_pqos.csv, log=/local/logs/pqos.log"
+  sleep 1
+  log_debug "pqos csv header (first 2 lines):"
+  head -n 2 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+
+  TSTAT_CMD="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
+  log_debug "Starting turbostat sidecar with: ${TSTAT_CMD}"
+  sudo -E bash -lc "exec ${TSTAT_CMD}" &
+  TURBOSTAT_PID=$!
+  log_debug "turbostat PID=${TURBOSTAT_PID}, out(txt)=${OUTDIR}/${IDTAG}_turbostat.txt"
+  sleep 1
+  log_debug "turbostat first 6 lines:"
+  head -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -702,24 +807,39 @@ if $run_pcm_power; then
     . path.sh
     export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-    taskset -c 6 /local/tools/pcm/build/bin/pcm-power 0.5 \
+    taskset -c '"${PCM_CPU}"' /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
-      -csv=/local/data/results/id_20_3gram_lm_pcm_power.csv -- \
+      -csv='"${OUTDIR}/${IDTAG}_pcm_power.csv"' -- \
       bash -lc "
         source /local/tools/bci_env/bin/activate
         . path.sh
         export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+        taskset -c '"${WORKLOAD_CPU}"' python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
           --lmDir=/local/data/languageModel/ \
           --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl
       "
-  ' >>/local/data/results/id_20_3gram_lm_pcm_power.log 2>&1
+  ' >>'"${OUTDIR}/${IDTAG}_pcm_power.log"' 2>&1
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_lm_pcm_power.log
   log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  stop_attribution_sidecars
+  trap - EXIT INT TERM
+  log_debug "pqos last 3 lines:"
+  tail -n 3 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+  log_debug "turbostat last 6 lines:"
+  tail -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+  if [[ -f "${OUTDIR}/${IDTAG}_turbostat.txt" ]]; then
+    awk 'BEGIN{OFS=","}
+         $1=="Time_Of_Day_Seconds"{next}
+         $2=="-"{next}
+         NF>0 {gsub(/[[:space:]]+/,","); print}
+    ' "${OUTDIR}/${IDTAG}_turbostat.txt" > "${OUTDIR}/${IDTAG}_turbostat.csv"
+    log_debug "turbostat CSV (first 6 lines):"
+    head -n 6 "${OUTDIR}/${IDTAG}_turbostat.csv" 2>/dev/null || true
+  fi
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -87,6 +87,24 @@ log_debug() {
     printf '[DEBUG] %s\n' "$*"
   fi
 }
+
+PQOS_PID=""
+TURBOSTAT_PID=""
+
+stop_attribution_sidecars() {
+  if [[ -n ${PQOS_PID:-} ]]; then
+    log_debug "Stopping pqos sidecar (PID ${PQOS_PID})"
+    kill -TERM "$PQOS_PID" 2>/dev/null || true
+    wait "$PQOS_PID" 2>/dev/null || true
+    PQOS_PID=""
+  fi
+  if [[ -n ${TURBOSTAT_PID:-} ]]; then
+    log_debug "Stopping turbostat sidecar (PID ${TURBOSTAT_PID})"
+    kill -TERM "$TURBOSTAT_PID" 2>/dev/null || true
+    wait "$TURBOSTAT_PID" 2>/dev/null || true
+    TURBOSTAT_PID=""
+  fi
+}
 turbo_state="${TURBO_STATE:-off}"
 pkg_cap_w="${PKG_W:-15}"
 dram_cap_w="${DRAM_W:-5}"
@@ -229,6 +247,68 @@ if $debug_enabled; then
   log_debug "  effective user: ${effective_user} (uid=${UID})"
   log_debug "  effective group: ${effective_group} (gid=${effective_gid})"
 fi
+
+WORKLOAD_CPU=${WORKLOAD_CPU:-6}
+PCM_CPU=${PCM_CPU:-5}
+TOOLS_CPU=${TOOLS_CPU:-1}
+OUTDIR=${OUTDIR:-/local/data/results}
+IDTAG=${IDTAG:-id_20_3gram_rnn}
+TS_INTERVAL=${TS_INTERVAL:-0.5}
+PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
+mkdir -p "$OUTDIR"
+
+ONLINE_MASK="$(cat /sys/devices/system/cpu/online)"
+OTHERS="$(awk -v excl="$WORKLOAD_CPU" '
+  function emit(a,b){
+    for(i=a;i<=b;i++) {
+      if(i!=excl) {
+        out = out (out? ",":"") i
+      }
+    }
+  }
+  BEGIN {
+    while((getline<"/sys/devices/system/cpu/online")>0){
+      n=split($0,a,",");
+      for(k=1;k<=n;k++){
+        if(a[k]~/-/){
+          split(a[k],r,"-");
+          emit(r[1],r[2])
+        } else {
+          emit(a[k],a[k])
+        }
+      }
+    }
+    print out
+  }
+')"
+
+if [[ "$TOOLS_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$PCM_CPU" ]]; then
+      TOOLS_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ "$PCM_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$TOOLS_CPU" ]]; then
+      PCM_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+log_debug "Attribution config:"
+log_debug "  WORKLOAD_CPU=${WORKLOAD_CPU}, PCM_CPU=${PCM_CPU}, TOOLS_CPU=${TOOLS_CPU}"
+log_debug "  ONLINE_MASK=${ONLINE_MASK}"
+log_debug "  OTHERS=${OTHERS}"
+log_debug "  OUTDIR=${OUTDIR}, IDTAG=${IDTAG}, intervals: pqos=${PQOS_INTERVAL_TICKS}*100ms, turbostat=${TS_INTERVAL}s"
 
 turbo_state="${turbo_state,,}"
 case "$turbo_state" in
@@ -692,8 +772,33 @@ if $run_pcm_power; then
   echo "----------------------------"
   echo "PCM-POWER"
   echo "----------------------------"
-  log_debug "Launching pcm-power (CSV=/local/data/results/id_20_3gram_rnn_pcm_power.csv, log=/local/data/results/id_20_3gram_rnn_pcm_power.log, profiler CPU=5, workload CPU=6)"
+  log_debug "Launching pcm-power (CSV=${OUTDIR}/${IDTAG}_pcm_power.csv, log=${OUTDIR}/${IDTAG}_pcm_power.log, profiler CPU=${PCM_CPU}, workload CPU=${WORKLOAD_CPU})"
   idle_wait
+
+  pqos_groups="mbt:[${WORKLOAD_CPU}]"
+  if [[ -n "${OTHERS}" ]]; then
+    pqos_groups+=";mbt:[${OTHERS}]"
+  fi
+
+  PQOS_CMD="taskset -c ${TOOLS_CPU} pqos -I -u csv -o ${OUTDIR}/${IDTAG}_pqos.csv -i ${PQOS_INTERVAL_TICKS} -m '${pqos_groups}'"
+  trap 'stop_attribution_sidecars' EXIT INT TERM
+  log_debug "Starting pqos sidecar with: ${PQOS_CMD}"
+  sudo nohup bash -lc "exec ${PQOS_CMD}" >/local/logs/pqos.log 2>&1 &
+  PQOS_PID=$!
+  log_debug "pqos PID=${PQOS_PID}, output=${OUTDIR}/${IDTAG}_pqos.csv, log=/local/logs/pqos.log"
+  sleep 1
+  log_debug "pqos csv header (first 2 lines):"
+  head -n 2 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+
+  TSTAT_CMD="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
+  log_debug "Starting turbostat sidecar with: ${TSTAT_CMD}"
+  sudo -E bash -lc "exec ${TSTAT_CMD}" &
+  TURBOSTAT_PID=$!
+  log_debug "turbostat PID=${TURBOSTAT_PID}, out(txt)=${OUTDIR}/${IDTAG}_turbostat.txt"
+  sleep 1
+  log_debug "turbostat first 6 lines:"
+  head -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo -E bash -lc '
@@ -702,24 +807,39 @@ if $run_pcm_power; then
     . path.sh
     export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-    taskset -c 6 /local/tools/pcm/build/bin/pcm-power 0.5 \
+    taskset -c '"${PCM_CPU}"' /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
-      -csv=/local/data/results/id_20_3gram_rnn_pcm_power.csv -- \
+      -csv='"${OUTDIR}/${IDTAG}_pcm_power.csv"' -- \
       bash -lc "
         source /local/tools/bci_env/bin/activate
         . path.sh
         export PYTHONPATH=\"\$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:\${PYTHONPATH:-}\"
-        python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+        taskset -c '"${WORKLOAD_CPU}"' python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
           --datasetPath=/local/data/ptDecoder_ctc \
           --modelPath=/local/data/speechBaseline4/
       "
-  ' >>/local/data/results/id_20_3gram_rnn_pcm_power.log 2>&1
+  ' >>'"${OUTDIR}/${IDTAG}_pcm_power.log"' 2>&1
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
   pcm_power_runtime=$((pcm_power_end - pcm_power_start))
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_rnn_pcm_power.log
   log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  stop_attribution_sidecars
+  trap - EXIT INT TERM
+  log_debug "pqos last 3 lines:"
+  tail -n 3 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+  log_debug "turbostat last 6 lines:"
+  tail -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+  if [[ -f "${OUTDIR}/${IDTAG}_turbostat.txt" ]]; then
+    awk 'BEGIN{OFS=","}
+         $1=="Time_Of_Day_Seconds"{next}
+         $2=="-"{next}
+         NF>0 {gsub(/[[:space:]]+/,","); print}
+    ' "${OUTDIR}/${IDTAG}_turbostat.txt" > "${OUTDIR}/${IDTAG}_turbostat.csv"
+    log_debug "turbostat CSV (first 6 lines):"
+    head -n 6 "${OUTDIR}/${IDTAG}_turbostat.csv" 2>/dev/null || true
+  fi
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -87,6 +87,24 @@ log_debug() {
     printf '[DEBUG] %s\n' "$*"
   fi
 }
+
+PQOS_PID=""
+TURBOSTAT_PID=""
+
+stop_attribution_sidecars() {
+  if [[ -n ${PQOS_PID:-} ]]; then
+    log_debug "Stopping pqos sidecar (PID ${PQOS_PID})"
+    kill -TERM "$PQOS_PID" 2>/dev/null || true
+    wait "$PQOS_PID" 2>/dev/null || true
+    PQOS_PID=""
+  fi
+  if [[ -n ${TURBOSTAT_PID:-} ]]; then
+    log_debug "Stopping turbostat sidecar (PID ${TURBOSTAT_PID})"
+    kill -TERM "$TURBOSTAT_PID" 2>/dev/null || true
+    wait "$TURBOSTAT_PID" 2>/dev/null || true
+    TURBOSTAT_PID=""
+  fi
+}
 turbo_state="${TURBO_STATE:-off}"
 pkg_cap_w="${PKG_W:-15}"
 dram_cap_w="${DRAM_W:-5}"
@@ -229,6 +247,68 @@ if $debug_enabled; then
   log_debug "  effective user: ${effective_user} (uid=${UID})"
   log_debug "  effective group: ${effective_group} (gid=${effective_gid})"
 fi
+
+WORKLOAD_CPU=${WORKLOAD_CPU:-6}
+PCM_CPU=${PCM_CPU:-5}
+TOOLS_CPU=${TOOLS_CPU:-1}
+OUTDIR=${OUTDIR:-/local/data/results}
+IDTAG=${IDTAG:-id_3}
+TS_INTERVAL=${TS_INTERVAL:-0.5}
+PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
+mkdir -p "$OUTDIR"
+
+ONLINE_MASK="$(cat /sys/devices/system/cpu/online)"
+OTHERS="$(awk -v excl="$WORKLOAD_CPU" '
+  function emit(a,b){
+    for(i=a;i<=b;i++) {
+      if(i!=excl) {
+        out = out (out? ",":"") i
+      }
+    }
+  }
+  BEGIN {
+    while((getline<"/sys/devices/system/cpu/online")>0){
+      n=split($0,a,",");
+      for(k=1;k<=n;k++){
+        if(a[k]~/-/){
+          split(a[k],r,"-");
+          emit(r[1],r[2])
+        } else {
+          emit(a[k],a[k])
+        }
+      }
+    }
+    print out
+  }
+')"
+
+if [[ "$TOOLS_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$PCM_CPU" ]]; then
+      TOOLS_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ "$PCM_CPU" == "$WORKLOAD_CPU" ]]; then
+  IFS=',' read -ra cpu_candidates <<< "$OTHERS"
+  for candidate in "${cpu_candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ "$candidate" != "$TOOLS_CPU" ]]; then
+      PCM_CPU="$candidate"
+      break
+    fi
+  done
+fi
+
+log_debug "Attribution config:"
+log_debug "  WORKLOAD_CPU=${WORKLOAD_CPU}, PCM_CPU=${PCM_CPU}, TOOLS_CPU=${TOOLS_CPU}"
+log_debug "  ONLINE_MASK=${ONLINE_MASK}"
+log_debug "  OTHERS=${OTHERS}"
+log_debug "  OUTDIR=${OUTDIR}, IDTAG=${IDTAG}, intervals: pqos=${PQOS_INTERVAL_TICKS}*100ms, turbostat=${TS_INTERVAL}s"
 
 turbo_state="${turbo_state,,}"
 case "$turbo_state" in
@@ -667,18 +747,43 @@ if $run_pcm_power; then
   echo "----------------------------"
   echo "PCM-POWER"
   echo "----------------------------"
-  log_debug "Launching pcm-power (CSV=/local/data/results/id_3_pcm_power.csv, log=/local/data/results/id_3_pcm_power.log, profiler CPU=5, workload CPU=6)"
+  log_debug "Launching pcm-power (CSV=${OUTDIR}/${IDTAG}_pcm_power.csv, log=${OUTDIR}/${IDTAG}_pcm_power.log, profiler CPU=${PCM_CPU}, workload CPU=${WORKLOAD_CPU})"
   idle_wait
+
+  pqos_groups="mbt:[${WORKLOAD_CPU}]"
+  if [[ -n "${OTHERS}" ]]; then
+    pqos_groups+=";mbt:[${OTHERS}]"
+  fi
+
+  PQOS_CMD="taskset -c ${TOOLS_CPU} pqos -I -u csv -o ${OUTDIR}/${IDTAG}_pqos.csv -i ${PQOS_INTERVAL_TICKS} -m '${pqos_groups}'"
+  trap 'stop_attribution_sidecars' EXIT INT TERM
+  log_debug "Starting pqos sidecar with: ${PQOS_CMD}"
+  sudo nohup bash -lc "exec ${PQOS_CMD}" >/local/logs/pqos.log 2>&1 &
+  PQOS_PID=$!
+  log_debug "pqos PID=${PQOS_PID}, output=${OUTDIR}/${IDTAG}_pqos.csv, log=/local/logs/pqos.log"
+  sleep 1
+  log_debug "pqos csv header (first 2 lines):"
+  head -n 2 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+
+  TSTAT_CMD="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
+  log_debug "Starting turbostat sidecar with: ${TSTAT_CMD}"
+  sudo -E bash -lc "exec ${TSTAT_CMD}" &
+  TURBOSTAT_PID=$!
+  log_debug "turbostat PID=${TURBOSTAT_PID}, out(txt)=${OUTDIR}/${IDTAG}_turbostat.txt"
+  sleep 1
+  log_debug "turbostat first 6 lines:"
+  head -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+
   echo "pcm-power started at: $(timestamp)"
   pcm_power_start=$(date +%s)
   sudo bash -lc '
     source /local/tools/compression_env/bin/activate
     cd /local/bci_code/id_3/code
-    taskset -c 5 /local/tools/pcm/build/bin/pcm-power 0.5 \
+    taskset -c '"${PCM_CPU}"' /local/tools/pcm/build/bin/pcm-power 0.5 \
       -p 0 -a 10 -b 20 -c 30 \
-      -csv=/local/data/results/id_3_pcm_power.csv -- \
-      taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_pcm_power.csv \
-    >>/local/data/results/id_3_pcm_power.log 2>&1
+      -csv='"${OUTDIR}/${IDTAG}_pcm_power.csv"' -- \
+      taskset -c '"${WORKLOAD_CPU}"' /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac '"${OUTDIR}/workload_pcm_power.csv"' \
+    >>'"${OUTDIR}/${IDTAG}_pcm_power.log"' 2>&1
   '
   pcm_power_end=$(date +%s)
   echo "pcm-power finished at: $(timestamp)"
@@ -686,6 +791,21 @@ if $run_pcm_power; then
   echo "pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")" \
     > /local/data/results/done_pcm_power.log
   log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  stop_attribution_sidecars
+  trap - EXIT INT TERM
+  log_debug "pqos last 3 lines:"
+  tail -n 3 "${OUTDIR}/${IDTAG}_pqos.csv" 2>/dev/null || true
+  log_debug "turbostat last 6 lines:"
+  tail -n 6 "${OUTDIR}/${IDTAG}_turbostat.txt" 2>/dev/null || true
+  if [[ -f "${OUTDIR}/${IDTAG}_turbostat.txt" ]]; then
+    awk 'BEGIN{OFS=","}
+         $1=="Time_Of_Day_Seconds"{next}
+         $2=="-"{next}
+         NF>0 {gsub(/[[:space:]]+/,","); print}
+    ' "${OUTDIR}/${IDTAG}_turbostat.txt" > "${OUTDIR}/${IDTAG}_turbostat.csv"
+    log_debug "turbostat CSV (first 6 lines):"
+    head -n 6 "${OUTDIR}/${IDTAG}_turbostat.csv" 2>/dev/null || true
+  fi
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then


### PR DESCRIPTION
## Summary
- add reusable pqos/turbostat sidecar management and CPU discovery to each run script
- wrap pcm-power execution with pqos and turbostat sampling plus turbostat-to-CSV conversion
- ensure new outputs and logs are routed through configurable OUTDIR/IDTAG defaults

## Testing
- bash -n scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh scripts/run_20_3gram_rnn.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9d1876c78832c8d120f7580bf465b