### PR TITLE
Silence turbostat output in run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -511,7 +511,7 @@ start_power_sidecars() {
 
   local turbostat_cmd="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
   echo "[turbostat] cmd: ${turbostat_cmd}" | tee -a "${LOGDIR}/turbostat.log"
-  sudo -E bash -lc "exec ${turbostat_cmd}" >>"${LOGDIR}/turbostat.log" 2>&1 &
+  sudo -E bash -lc "exec ${turbostat_cmd}" >/dev/null 2>>"${LOGDIR}/turbostat.log" &
   TURBOSTAT_PID=$!
   echo "[turbostat] pid=${TURBOSTAT_PID}, out=${OUTDIR}/${IDTAG}_turbostat.txt, log=${LOGDIR}/turbostat.log"
 

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -511,7 +511,7 @@ start_power_sidecars() {
 
   local turbostat_cmd="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
   echo "[turbostat] cmd: ${turbostat_cmd}" | tee -a "${LOGDIR}/turbostat.log"
-  sudo -E bash -lc "exec ${turbostat_cmd}" >>"${LOGDIR}/turbostat.log" 2>&1 &
+  sudo -E bash -lc "exec ${turbostat_cmd}" >/dev/null 2>>"${LOGDIR}/turbostat.log" &
   TURBOSTAT_PID=$!
   echo "[turbostat] pid=${TURBOSTAT_PID}, out=${OUTDIR}/${IDTAG}_turbostat.txt, log=${LOGDIR}/turbostat.log"
 

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -511,7 +511,7 @@ start_power_sidecars() {
 
   local turbostat_cmd="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
   echo "[turbostat] cmd: ${turbostat_cmd}" | tee -a "${LOGDIR}/turbostat.log"
-  sudo -E bash -lc "exec ${turbostat_cmd}" >>"${LOGDIR}/turbostat.log" 2>&1 &
+  sudo -E bash -lc "exec ${turbostat_cmd}" >/dev/null 2>>"${LOGDIR}/turbostat.log" &
   TURBOSTAT_PID=$!
   echo "[turbostat] pid=${TURBOSTAT_PID}, out=${OUTDIR}/${IDTAG}_turbostat.txt, log=${LOGDIR}/turbostat.log"
 

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -511,7 +511,7 @@ start_power_sidecars() {
 
   local turbostat_cmd="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
   echo "[turbostat] cmd: ${turbostat_cmd}" | tee -a "${LOGDIR}/turbostat.log"
-  sudo -E bash -lc "exec ${turbostat_cmd}" >>"${LOGDIR}/turbostat.log" 2>&1 &
+  sudo -E bash -lc "exec ${turbostat_cmd}" >/dev/null 2>>"${LOGDIR}/turbostat.log" &
   TURBOSTAT_PID=$!
   echo "[turbostat] pid=${TURBOSTAT_PID}, out=${OUTDIR}/${IDTAG}_turbostat.txt, log=${LOGDIR}/turbostat.log"
 

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -511,7 +511,7 @@ start_power_sidecars() {
 
   local turbostat_cmd="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
   echo "[turbostat] cmd: ${turbostat_cmd}" | tee -a "${LOGDIR}/turbostat.log"
-  sudo -E bash -lc "exec ${turbostat_cmd}" >>"${LOGDIR}/turbostat.log" 2>&1 &
+  sudo -E bash -lc "exec ${turbostat_cmd}" >/dev/null 2>>"${LOGDIR}/turbostat.log" &
   TURBOSTAT_PID=$!
   echo "[turbostat] pid=${TURBOSTAT_PID}, out=${OUTDIR}/${IDTAG}_turbostat.txt, log=${LOGDIR}/turbostat.log"
 

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -511,7 +511,7 @@ start_power_sidecars() {
 
   local turbostat_cmd="taskset -c ${TOOLS_CPU} turbostat --interval ${TS_INTERVAL} --quiet --enable Time_Of_Day_Seconds --show Time_Of_Day_Seconds,CPU,Busy%,Bzy_MHz --out ${OUTDIR}/${IDTAG}_turbostat.txt"
   echo "[turbostat] cmd: ${turbostat_cmd}" | tee -a "${LOGDIR}/turbostat.log"
-  sudo -E bash -lc "exec ${turbostat_cmd}" >>"${LOGDIR}/turbostat.log" 2>&1 &
+  sudo -E bash -lc "exec ${turbostat_cmd}" >/dev/null 2>>"${LOGDIR}/turbostat.log" &
   TURBOSTAT_PID=$!
   echo "[turbostat] pid=${TURBOSTAT_PID}, out=${OUTDIR}/${IDTAG}_turbostat.txt, log=${LOGDIR}/turbostat.log"
 


### PR DESCRIPTION
## Summary
- ensure turbostat measurements are no longer mirrored to stdout by redirecting the background process output to /dev/null
- keep error reporting by sending stderr to the existing turbostat log while leaving measurement capture in the .txt file untouched across all run scripts

## Testing
- not run (cloud/hardware dependent)

------
https://chatgpt.com/codex/tasks/task_e_68d9fa20da4c832ca18efe5b2849e158