### PR TITLE
Fix pcm-power completion artifacts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -868,14 +868,15 @@ if $run_pcm_power; then
   summary_lines=("pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")")
   if [[ -n ${PQOS_START_TS} && -n ${PQOS_STOP_TS} ]]; then
     pqos_overlap=$((PQOS_STOP_TS - PQOS_START_TS))
-    summary_lines+=("pqos runtime (overlap with pcm-power): ${pqos_overlap}s")
+    summary_lines+=("pqos runtime (overlap with pcm-power): $(secs_to_dhm "$pqos_overlap")")
   fi
   if [[ -n ${TSTAT_START_TS} && -n ${TSTAT_STOP_TS} ]]; then
     tstat_overlap=$((TSTAT_STOP_TS - TSTAT_START_TS))
-    summary_lines+=("turbostat runtime (overlap with pcm-power): ${tstat_overlap}s")
+    summary_lines+=("turbostat runtime (overlap with pcm-power): $(secs_to_dhm "$tstat_overlap")")
   fi
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/${IDTAG}_pcm_power.done"
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/done_pcm_power.log"
+  rm -f "${OUTDIR}/${IDTAG}_pcm_power.done"
 
   turbostat_txt="${RESULT_PREFIX}_turbostat.txt"
   turbostat_csv="${RESULT_PREFIX}_turbostat.csv"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -892,14 +892,15 @@ if $run_pcm_power; then
   summary_lines=("pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")")
   if [[ -n ${PQOS_START_TS} && -n ${PQOS_STOP_TS} ]]; then
     pqos_overlap=$((PQOS_STOP_TS - PQOS_START_TS))
-    summary_lines+=("pqos runtime (overlap with pcm-power): ${pqos_overlap}s")
+    summary_lines+=("pqos runtime (overlap with pcm-power): $(secs_to_dhm "$pqos_overlap")")
   fi
   if [[ -n ${TSTAT_START_TS} && -n ${TSTAT_STOP_TS} ]]; then
     tstat_overlap=$((TSTAT_STOP_TS - TSTAT_START_TS))
-    summary_lines+=("turbostat runtime (overlap with pcm-power): ${tstat_overlap}s")
+    summary_lines+=("turbostat runtime (overlap with pcm-power): $(secs_to_dhm "$tstat_overlap")")
   fi
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/${IDTAG}_pcm_power.done"
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/done_pcm_power.log"
+  rm -f "${OUTDIR}/${IDTAG}_pcm_power.done"
 
   turbostat_txt="${RESULT_PREFIX}_turbostat.txt"
   turbostat_csv="${RESULT_PREFIX}_turbostat.csv"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -912,14 +912,15 @@ if $run_pcm_power; then
   summary_lines=("pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")")
   if [[ -n ${PQOS_START_TS} && -n ${PQOS_STOP_TS} ]]; then
     pqos_overlap=$((PQOS_STOP_TS - PQOS_START_TS))
-    summary_lines+=("pqos runtime (overlap with pcm-power): ${pqos_overlap}s")
+    summary_lines+=("pqos runtime (overlap with pcm-power): $(secs_to_dhm "$pqos_overlap")")
   fi
   if [[ -n ${TSTAT_START_TS} && -n ${TSTAT_STOP_TS} ]]; then
     tstat_overlap=$((TSTAT_STOP_TS - TSTAT_START_TS))
-    summary_lines+=("turbostat runtime (overlap with pcm-power): ${tstat_overlap}s")
+    summary_lines+=("turbostat runtime (overlap with pcm-power): $(secs_to_dhm "$tstat_overlap")")
   fi
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/${IDTAG}_pcm_power.done"
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/done_llm_pcm_power.log"
+  rm -f "${OUTDIR}/${IDTAG}_pcm_power.done"
 
   turbostat_txt="${RESULT_PREFIX}_turbostat.txt"
   turbostat_csv="${RESULT_PREFIX}_turbostat.csv"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -912,14 +912,15 @@ if $run_pcm_power; then
   summary_lines=("pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")")
   if [[ -n ${PQOS_START_TS} && -n ${PQOS_STOP_TS} ]]; then
     pqos_overlap=$((PQOS_STOP_TS - PQOS_START_TS))
-    summary_lines+=("pqos runtime (overlap with pcm-power): ${pqos_overlap}s")
+    summary_lines+=("pqos runtime (overlap with pcm-power): $(secs_to_dhm "$pqos_overlap")")
   fi
   if [[ -n ${TSTAT_START_TS} && -n ${TSTAT_STOP_TS} ]]; then
     tstat_overlap=$((TSTAT_STOP_TS - TSTAT_START_TS))
-    summary_lines+=("turbostat runtime (overlap with pcm-power): ${tstat_overlap}s")
+    summary_lines+=("turbostat runtime (overlap with pcm-power): $(secs_to_dhm "$tstat_overlap")")
   fi
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/${IDTAG}_pcm_power.done"
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/done_lm_pcm_power.log"
+  rm -f "${OUTDIR}/${IDTAG}_pcm_power.done"
 
   turbostat_txt="${RESULT_PREFIX}_turbostat.txt"
   turbostat_csv="${RESULT_PREFIX}_turbostat.csv"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -912,14 +912,15 @@ if $run_pcm_power; then
   summary_lines=("pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")")
   if [[ -n ${PQOS_START_TS} && -n ${PQOS_STOP_TS} ]]; then
     pqos_overlap=$((PQOS_STOP_TS - PQOS_START_TS))
-    summary_lines+=("pqos runtime (overlap with pcm-power): ${pqos_overlap}s")
+    summary_lines+=("pqos runtime (overlap with pcm-power): $(secs_to_dhm "$pqos_overlap")")
   fi
   if [[ -n ${TSTAT_START_TS} && -n ${TSTAT_STOP_TS} ]]; then
     tstat_overlap=$((TSTAT_STOP_TS - TSTAT_START_TS))
-    summary_lines+=("turbostat runtime (overlap with pcm-power): ${tstat_overlap}s")
+    summary_lines+=("turbostat runtime (overlap with pcm-power): $(secs_to_dhm "$tstat_overlap")")
   fi
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/${IDTAG}_pcm_power.done"
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/done_rnn_pcm_power.log"
+  rm -f "${OUTDIR}/${IDTAG}_pcm_power.done"
 
   turbostat_txt="${RESULT_PREFIX}_turbostat.txt"
   turbostat_csv="${RESULT_PREFIX}_turbostat.csv"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -878,14 +878,15 @@ if $run_pcm_power; then
   summary_lines=("pcm-power runtime: $(secs_to_dhm "$pcm_power_runtime")")
   if [[ -n ${PQOS_START_TS} && -n ${PQOS_STOP_TS} ]]; then
     pqos_overlap=$((PQOS_STOP_TS - PQOS_START_TS))
-    summary_lines+=("pqos runtime (overlap with pcm-power): ${pqos_overlap}s")
+    summary_lines+=("pqos runtime (overlap with pcm-power): $(secs_to_dhm "$pqos_overlap")")
   fi
   if [[ -n ${TSTAT_START_TS} && -n ${TSTAT_STOP_TS} ]]; then
     tstat_overlap=$((TSTAT_STOP_TS - TSTAT_START_TS))
-    summary_lines+=("turbostat runtime (overlap with pcm-power): ${tstat_overlap}s")
+    summary_lines+=("turbostat runtime (overlap with pcm-power): $(secs_to_dhm "$tstat_overlap")")
   fi
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/${IDTAG}_pcm_power.done"
   printf '%s\n' "${summary_lines[@]}" > "${OUTDIR}/done_pcm_power.log"
+  rm -f "${OUTDIR}/${IDTAG}_pcm_power.done"
 
   turbostat_txt="${RESULT_PREFIX}_turbostat.txt"
   turbostat_csv="${RESULT_PREFIX}_turbostat.csv"


### PR DESCRIPTION
## Summary
- remove the leftover pcm-power .done file after its contents are copied into the done log
- report pqos and turbostat pcm-power overlap durations in day/hour/minute format via secs_to_dhm

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1ba3c040832c9bffae717f90bbd1