### PR TITLE
Export shared knobs from all run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -36,6 +36,9 @@ IDTAG=${IDTAG:-id_1}
 TS_INTERVAL=${TS_INTERVAL:-0.5}
 PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
 
+# Ensure shared knobs are visible to child processes (e.g., inline Python blocks).
+export WORKLOAD_CPU PCM_CPU TOOLS_CPU OUTDIR LOGDIR IDTAG TS_INTERVAL PQOS_INTERVAL_TICKS
+
 RESULT_PREFIX="${OUTDIR}/${IDTAG}"
 
 # Create unified log file

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -36,6 +36,9 @@ IDTAG=${IDTAG:-id_13}
 TS_INTERVAL=${TS_INTERVAL:-0.5}
 PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
 
+# Ensure shared knobs are visible to child processes (e.g., inline Python blocks).
+export WORKLOAD_CPU PCM_CPU TOOLS_CPU OUTDIR LOGDIR IDTAG TS_INTERVAL PQOS_INTERVAL_TICKS
+
 RESULT_PREFIX="${OUTDIR}/${IDTAG}"
 
 # Create unified log file

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -36,6 +36,9 @@ IDTAG=${IDTAG:-id_20_3gram_llm}
 TS_INTERVAL=${TS_INTERVAL:-0.5}
 PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
 
+# Ensure shared knobs are visible to child processes (e.g., inline Python blocks).
+export WORKLOAD_CPU PCM_CPU TOOLS_CPU OUTDIR LOGDIR IDTAG TS_INTERVAL PQOS_INTERVAL_TICKS
+
 RESULT_PREFIX="${OUTDIR}/${IDTAG}"
 
 # Create unified log file

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -36,6 +36,9 @@ IDTAG=${IDTAG:-id_20_3gram_lm}
 TS_INTERVAL=${TS_INTERVAL:-0.5}
 PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
 
+# Ensure shared knobs are visible to child processes (e.g., inline Python blocks).
+export WORKLOAD_CPU PCM_CPU TOOLS_CPU OUTDIR LOGDIR IDTAG TS_INTERVAL PQOS_INTERVAL_TICKS
+
 RESULT_PREFIX="${OUTDIR}/${IDTAG}"
 
 # Create unified log file

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -36,6 +36,9 @@ IDTAG=${IDTAG:-id_20_3gram_rnn}
 TS_INTERVAL=${TS_INTERVAL:-0.5}
 PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
 
+# Ensure shared knobs are visible to child processes (e.g., inline Python blocks).
+export WORKLOAD_CPU PCM_CPU TOOLS_CPU OUTDIR LOGDIR IDTAG TS_INTERVAL PQOS_INTERVAL_TICKS
+
 RESULT_PREFIX="${OUTDIR}/${IDTAG}"
 
 # Create unified log file

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -36,6 +36,9 @@ IDTAG=${IDTAG:-id_3}
 TS_INTERVAL=${TS_INTERVAL:-0.5}
 PQOS_INTERVAL_TICKS=${PQOS_INTERVAL_TICKS:-5}
 
+# Ensure shared knobs are visible to child processes (e.g., inline Python blocks).
+export WORKLOAD_CPU PCM_CPU TOOLS_CPU OUTDIR LOGDIR IDTAG TS_INTERVAL PQOS_INTERVAL_TICKS
+
 RESULT_PREFIX="${OUTDIR}/${IDTAG}"
 
 # Create unified log file


### PR DESCRIPTION
## Summary
- export the shared environment knobs in each run script so child Python blocks can read them

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc632fda3c832c9354cafe783ddb5d