### PR TITLE
Preserve pcm-power CSV metadata and trailing columns

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1411,18 +1411,21 @@ def main():
         row.append(f"{pkg_filled[idx]:.6f}")
         row.append(f"{dram_filled[idx]:.6f}")
 
-    if ghost:
-        header1.append("")
-        header2.append("")
-        for row in data_rows:
-            row.append("")
-
     log(f"writeback: pre_shape={row_count}x{cols_before}, post_shape={row_count}x{cols_after}")
     log(f"writeback: appended_headers={appended_headers}")
-    log(f"writeback: ghost_readded={'yes' if ghost else 'no'}")
+    log(
+        "writeback: ghost_readded={}".format(
+            "no (dropped empty column)" if ghost else "not needed"
+        )
+    )
     header2_tail_after = header2[-6:] if len(header2) >= 6 else header2[:]
     log(f"header2 tail after write: {header2_tail_after}")
 
+    try:
+        stat_info = os.stat(pcm_path)
+    except FileNotFoundError:
+        stat_info = None
+        warn("pcm-power CSV missing when capturing permissions; skipping restore")
     tmp_file = tempfile.NamedTemporaryFile("w", delete=False, dir=str(pcm_path.parent), newline="")
     try:
         writer = csv.writer(tmp_file)
@@ -1432,6 +1435,13 @@ def main():
     finally:
         tmp_file.close()
     os.replace(tmp_file.name, pcm_path)
+    if stat_info is not None:
+        try:
+            os.chmod(pcm_path, stat_info.st_mode & 0o777)
+            if os.geteuid() == 0:
+                os.chown(pcm_path, stat_info.st_uid, stat_info.st_gid)
+        except OSError as exc:
+            warn(f"failed to restore pcm-power CSV permissions: {exc}")
 
     with open(pcm_path, "r", newline="") as f:
         raw_lines = f.read().splitlines()

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1435,18 +1435,21 @@ def main():
         row.append(f"{pkg_filled[idx]:.6f}")
         row.append(f"{dram_filled[idx]:.6f}")
 
-    if ghost:
-        header1.append("")
-        header2.append("")
-        for row in data_rows:
-            row.append("")
-
     log(f"writeback: pre_shape={row_count}x{cols_before}, post_shape={row_count}x{cols_after}")
     log(f"writeback: appended_headers={appended_headers}")
-    log(f"writeback: ghost_readded={'yes' if ghost else 'no'}")
+    log(
+        "writeback: ghost_readded={}".format(
+            "no (dropped empty column)" if ghost else "not needed"
+        )
+    )
     header2_tail_after = header2[-6:] if len(header2) >= 6 else header2[:]
     log(f"header2 tail after write: {header2_tail_after}")
 
+    try:
+        stat_info = os.stat(pcm_path)
+    except FileNotFoundError:
+        stat_info = None
+        warn("pcm-power CSV missing when capturing permissions; skipping restore")
     tmp_file = tempfile.NamedTemporaryFile("w", delete=False, dir=str(pcm_path.parent), newline="")
     try:
         writer = csv.writer(tmp_file)
@@ -1456,6 +1459,13 @@ def main():
     finally:
         tmp_file.close()
     os.replace(tmp_file.name, pcm_path)
+    if stat_info is not None:
+        try:
+            os.chmod(pcm_path, stat_info.st_mode & 0o777)
+            if os.geteuid() == 0:
+                os.chown(pcm_path, stat_info.st_uid, stat_info.st_gid)
+        except OSError as exc:
+            warn(f"failed to restore pcm-power CSV permissions: {exc}")
 
     with open(pcm_path, "r", newline="") as f:
         raw_lines = f.read().splitlines()

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1455,18 +1455,21 @@ def main():
         row.append(f"{pkg_filled[idx]:.6f}")
         row.append(f"{dram_filled[idx]:.6f}")
 
-    if ghost:
-        header1.append("")
-        header2.append("")
-        for row in data_rows:
-            row.append("")
-
     log(f"writeback: pre_shape={row_count}x{cols_before}, post_shape={row_count}x{cols_after}")
     log(f"writeback: appended_headers={appended_headers}")
-    log(f"writeback: ghost_readded={'yes' if ghost else 'no'}")
+    log(
+        "writeback: ghost_readded={}".format(
+            "no (dropped empty column)" if ghost else "not needed"
+        )
+    )
     header2_tail_after = header2[-6:] if len(header2) >= 6 else header2[:]
     log(f"header2 tail after write: {header2_tail_after}")
 
+    try:
+        stat_info = os.stat(pcm_path)
+    except FileNotFoundError:
+        stat_info = None
+        warn("pcm-power CSV missing when capturing permissions; skipping restore")
     tmp_file = tempfile.NamedTemporaryFile("w", delete=False, dir=str(pcm_path.parent), newline="")
     try:
         writer = csv.writer(tmp_file)
@@ -1476,6 +1479,13 @@ def main():
     finally:
         tmp_file.close()
     os.replace(tmp_file.name, pcm_path)
+    if stat_info is not None:
+        try:
+            os.chmod(pcm_path, stat_info.st_mode & 0o777)
+            if os.geteuid() == 0:
+                os.chown(pcm_path, stat_info.st_uid, stat_info.st_gid)
+        except OSError as exc:
+            warn(f"failed to restore pcm-power CSV permissions: {exc}")
 
     with open(pcm_path, "r", newline="") as f:
         raw_lines = f.read().splitlines()

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1455,18 +1455,21 @@ def main():
         row.append(f"{pkg_filled[idx]:.6f}")
         row.append(f"{dram_filled[idx]:.6f}")
 
-    if ghost:
-        header1.append("")
-        header2.append("")
-        for row in data_rows:
-            row.append("")
-
     log(f"writeback: pre_shape={row_count}x{cols_before}, post_shape={row_count}x{cols_after}")
     log(f"writeback: appended_headers={appended_headers}")
-    log(f"writeback: ghost_readded={'yes' if ghost else 'no'}")
+    log(
+        "writeback: ghost_readded={}".format(
+            "no (dropped empty column)" if ghost else "not needed"
+        )
+    )
     header2_tail_after = header2[-6:] if len(header2) >= 6 else header2[:]
     log(f"header2 tail after write: {header2_tail_after}")
 
+    try:
+        stat_info = os.stat(pcm_path)
+    except FileNotFoundError:
+        stat_info = None
+        warn("pcm-power CSV missing when capturing permissions; skipping restore")
     tmp_file = tempfile.NamedTemporaryFile("w", delete=False, dir=str(pcm_path.parent), newline="")
     try:
         writer = csv.writer(tmp_file)
@@ -1476,6 +1479,13 @@ def main():
     finally:
         tmp_file.close()
     os.replace(tmp_file.name, pcm_path)
+    if stat_info is not None:
+        try:
+            os.chmod(pcm_path, stat_info.st_mode & 0o777)
+            if os.geteuid() == 0:
+                os.chown(pcm_path, stat_info.st_uid, stat_info.st_gid)
+        except OSError as exc:
+            warn(f"failed to restore pcm-power CSV permissions: {exc}")
 
     with open(pcm_path, "r", newline="") as f:
         raw_lines = f.read().splitlines()


### PR DESCRIPTION
## Summary
- drop the ghost column so pcm-power CSV rows end with the new Actual Watts values
- capture existing pcm-power permissions when present and restore them after the atomic replace
- warn when permission restoration is skipped or fails instead of aborting the run

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6add7bf4832ca52ce496cc7b904d