### PR TITLE
Handle PQoS duplicate timestamps per sampling interval

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1287,12 +1287,31 @@ def main():
                     })
 
     pqos_samples = []
+    current_sample = None
     current_time = None
+    seen_cores = set()
     for entry in pqos_entries_raw:
-        if entry["time"] != current_time:
-            pqos_samples.append({"time": entry["time"], "rows": []})
-            current_time = entry["time"]
-        pqos_samples[-1]["rows"].append(entry)
+        time_value = entry["time"]
+        core_set = entry["core"]
+        if current_sample is None:
+            current_sample = {"time": time_value, "rows": []}
+            current_time = time_value
+            seen_cores = set()
+        else:
+            if time_value != current_time:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+            elif core_set in seen_cores:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+        current_sample["rows"].append(entry)
+        seen_cores.add(core_set)
+    if current_sample is not None:
+        pqos_samples.append(current_sample)
 
     has_subseconds = any("." in sample["time"].split()[-1] for sample in pqos_samples) if pqos_samples else False
     if pqos_samples:

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1311,12 +1311,31 @@ def main():
                     })
 
     pqos_samples = []
+    current_sample = None
     current_time = None
+    seen_cores = set()
     for entry in pqos_entries_raw:
-        if entry["time"] != current_time:
-            pqos_samples.append({"time": entry["time"], "rows": []})
-            current_time = entry["time"]
-        pqos_samples[-1]["rows"].append(entry)
+        time_value = entry["time"]
+        core_set = entry["core"]
+        if current_sample is None:
+            current_sample = {"time": time_value, "rows": []}
+            current_time = time_value
+            seen_cores = set()
+        else:
+            if time_value != current_time:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+            elif core_set in seen_cores:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+        current_sample["rows"].append(entry)
+        seen_cores.add(core_set)
+    if current_sample is not None:
+        pqos_samples.append(current_sample)
 
     has_subseconds = any("." in sample["time"].split()[-1] for sample in pqos_samples) if pqos_samples else False
     if pqos_samples:

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1331,12 +1331,31 @@ def main():
                     })
 
     pqos_samples = []
+    current_sample = None
     current_time = None
+    seen_cores = set()
     for entry in pqos_entries_raw:
-        if entry["time"] != current_time:
-            pqos_samples.append({"time": entry["time"], "rows": []})
-            current_time = entry["time"]
-        pqos_samples[-1]["rows"].append(entry)
+        time_value = entry["time"]
+        core_set = entry["core"]
+        if current_sample is None:
+            current_sample = {"time": time_value, "rows": []}
+            current_time = time_value
+            seen_cores = set()
+        else:
+            if time_value != current_time:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+            elif core_set in seen_cores:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+        current_sample["rows"].append(entry)
+        seen_cores.add(core_set)
+    if current_sample is not None:
+        pqos_samples.append(current_sample)
 
     has_subseconds = any("." in sample["time"].split()[-1] for sample in pqos_samples) if pqos_samples else False
     if pqos_samples:

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1331,12 +1331,31 @@ def main():
                     })
 
     pqos_samples = []
+    current_sample = None
     current_time = None
+    seen_cores = set()
     for entry in pqos_entries_raw:
-        if entry["time"] != current_time:
-            pqos_samples.append({"time": entry["time"], "rows": []})
-            current_time = entry["time"]
-        pqos_samples[-1]["rows"].append(entry)
+        time_value = entry["time"]
+        core_set = entry["core"]
+        if current_sample is None:
+            current_sample = {"time": time_value, "rows": []}
+            current_time = time_value
+            seen_cores = set()
+        else:
+            if time_value != current_time:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+            elif core_set in seen_cores:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+        current_sample["rows"].append(entry)
+        seen_cores.add(core_set)
+    if current_sample is not None:
+        pqos_samples.append(current_sample)
 
     has_subseconds = any("." in sample["time"].split()[-1] for sample in pqos_samples) if pqos_samples else False
     if pqos_samples:

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1331,12 +1331,31 @@ def main():
                     })
 
     pqos_samples = []
+    current_sample = None
     current_time = None
+    seen_cores = set()
     for entry in pqos_entries_raw:
-        if entry["time"] != current_time:
-            pqos_samples.append({"time": entry["time"], "rows": []})
-            current_time = entry["time"]
-        pqos_samples[-1]["rows"].append(entry)
+        time_value = entry["time"]
+        core_set = entry["core"]
+        if current_sample is None:
+            current_sample = {"time": time_value, "rows": []}
+            current_time = time_value
+            seen_cores = set()
+        else:
+            if time_value != current_time:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+            elif core_set in seen_cores:
+                pqos_samples.append(current_sample)
+                current_sample = {"time": time_value, "rows": []}
+                current_time = time_value
+                seen_cores = set()
+        current_sample["rows"].append(entry)
+        seen_cores.add(core_set)
+    if current_sample is not None:
+        pqos_samples.append(current_sample)
 
     has_subseconds = any("." in sample["time"].split()[-1] for sample in pqos_samples) if pqos_samples else False
     if pqos_samples:


### PR DESCRIPTION
## Summary
- adjust the PQoS aggregation helper to start a new sample when the same timestamp repeats with the same core set
- keep the synthetic sigma timeline spaced by the configured sampling interval so duplicate wall-clock strings map to sequential samples across all workloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd73fd81c4832cb809a151e84da3e8