### PR TITLE
Normalize PQoS group formatting across run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1021,15 +1021,15 @@ if $run_pcm_power; then
   export RDT_IFACE=OS
 
   if [[ ${MBM_AVAILABLE} -eq 1 ]]; then
-    PQOS_GROUPS="mbt:[${WORKLOAD_CPU}]"
+    PQOS_GROUPS="all:${WORKLOAD_CPU}"
     if [[ -n ${OTHERS} ]]; then
-      PQOS_GROUPS="${PQOS_GROUPS};mbt:[${OTHERS}]"
+      PQOS_GROUPS="${PQOS_GROUPS};all:${OTHERS}"
     fi
     printf -v PQOS_CMD "taskset -c %s pqos -I -u csv -o %q -i %s -m %q" \
       "${TOOLS_CPU}" "${RESULT_PREFIX}_pqos.csv" "${PQOS_INTERVAL_TICKS}" "${PQOS_GROUPS}"
     {
       printf '[pqos] cmd: %s\n' "${PQOS_CMD}"
-      printf '[pqos] groups: workload=[%s] others=[%s]\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
+      printf '[pqos] groups: workload=%s others=%s\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
     } >>"${PQOS_LOG}"
     if spawn_sidecar "pqos" "${PQOS_CMD}" "${PQOS_LOG}" PQOS_PID; then
       PQOS_START_TS=$(date +%s)
@@ -1545,6 +1545,8 @@ def main():
                     if math.isnan(mbt_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
+                    core_clean = core_clean.replace("[", "").replace("]", "")
+                    core_clean = core_clean.replace("{", "").replace("}", "")
                     if not core_clean:
                         continue
                     core_set = set()
@@ -1552,10 +1554,28 @@ def main():
                         part = part.strip()
                         if not part:
                             continue
-                        try:
-                            core_set.add(int(part))
-                        except ValueError:
+                        if ":" in part:
+                            part = part.split(":", 1)[1].strip()
+                        if not part:
                             continue
+                        if "-" in part:
+                            start_str, end_str = part.split("-", 1)
+                            try:
+                                start = int(start_str.strip())
+                                end = int(end_str.strip())
+                            except ValueError:
+                                continue
+                            if start <= end:
+                                core_set.update(range(start, end + 1))
+                            else:
+                                core_set.update(range(end, start + 1))
+                        else:
+                            try:
+                                core_set.add(int(part))
+                            except ValueError:
+                                continue
+                    if not core_set:
+                        continue
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1039,15 +1039,15 @@ if $run_pcm_power; then
   export RDT_IFACE=OS
 
   if [[ ${MBM_AVAILABLE} -eq 1 ]]; then
-    PQOS_GROUPS="mbt:[${WORKLOAD_CPU}]"
+    PQOS_GROUPS="all:${WORKLOAD_CPU}"
     if [[ -n ${OTHERS} ]]; then
-      PQOS_GROUPS="${PQOS_GROUPS};mbt:[${OTHERS}]"
+      PQOS_GROUPS="${PQOS_GROUPS};all:${OTHERS}"
     fi
     printf -v PQOS_CMD "taskset -c %s pqos -I -u csv -o %q -i %s -m %q" \
       "${TOOLS_CPU}" "${RESULT_PREFIX}_pqos.csv" "${PQOS_INTERVAL_TICKS}" "${PQOS_GROUPS}"
     {
       printf '[pqos] cmd: %s\n' "${PQOS_CMD}"
-      printf '[pqos] groups: workload=[%s] others=[%s]\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
+      printf '[pqos] groups: workload=%s others=%s\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
     } >>"${PQOS_LOG}"
     if spawn_sidecar "pqos" "${PQOS_CMD}" "${PQOS_LOG}" PQOS_PID; then
       PQOS_START_TS=$(date +%s)
@@ -1569,6 +1569,8 @@ def main():
                     if math.isnan(mbt_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
+                    core_clean = core_clean.replace("[", "").replace("]", "")
+                    core_clean = core_clean.replace("{", "").replace("}", "")
                     if not core_clean:
                         continue
                     core_set = set()
@@ -1576,10 +1578,28 @@ def main():
                         part = part.strip()
                         if not part:
                             continue
-                        try:
-                            core_set.add(int(part))
-                        except ValueError:
+                        if ":" in part:
+                            part = part.split(":", 1)[1].strip()
+                        if not part:
                             continue
+                        if "-" in part:
+                            start_str, end_str = part.split("-", 1)
+                            try:
+                                start = int(start_str.strip())
+                                end = int(end_str.strip())
+                            except ValueError:
+                                continue
+                            if start <= end:
+                                core_set.update(range(start, end + 1))
+                            else:
+                                core_set.update(range(end, start + 1))
+                        else:
+                            try:
+                                core_set.add(int(part))
+                            except ValueError:
+                                continue
+                    if not core_set:
+                        continue
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1054,15 +1054,15 @@ if $run_pcm_power; then
   export RDT_IFACE=OS
 
   if [[ ${MBM_AVAILABLE} -eq 1 ]]; then
-    PQOS_GROUPS="mbt:[${WORKLOAD_CPU}]"
+    PQOS_GROUPS="all:${WORKLOAD_CPU}"
     if [[ -n ${OTHERS} ]]; then
-      PQOS_GROUPS="${PQOS_GROUPS};mbt:[${OTHERS}]"
+      PQOS_GROUPS="${PQOS_GROUPS};all:${OTHERS}"
     fi
     printf -v PQOS_CMD "taskset -c %s pqos -I -u csv -o %q -i %s -m %q" \
       "${TOOLS_CPU}" "${RESULT_PREFIX}_pqos.csv" "${PQOS_INTERVAL_TICKS}" "${PQOS_GROUPS}"
     {
       printf '[pqos] cmd: %s\n' "${PQOS_CMD}"
-      printf '[pqos] groups: workload=[%s] others=[%s]\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
+      printf '[pqos] groups: workload=%s others=%s\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
     } >>"${PQOS_LOG}"
     if spawn_sidecar "pqos" "${PQOS_CMD}" "${PQOS_LOG}" PQOS_PID; then
       PQOS_START_TS=$(date +%s)
@@ -1589,6 +1589,8 @@ def main():
                     if math.isnan(mbt_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
+                    core_clean = core_clean.replace("[", "").replace("]", "")
+                    core_clean = core_clean.replace("{", "").replace("}", "")
                     if not core_clean:
                         continue
                     core_set = set()
@@ -1596,10 +1598,28 @@ def main():
                         part = part.strip()
                         if not part:
                             continue
-                        try:
-                            core_set.add(int(part))
-                        except ValueError:
+                        if ":" in part:
+                            part = part.split(":", 1)[1].strip()
+                        if not part:
                             continue
+                        if "-" in part:
+                            start_str, end_str = part.split("-", 1)
+                            try:
+                                start = int(start_str.strip())
+                                end = int(end_str.strip())
+                            except ValueError:
+                                continue
+                            if start <= end:
+                                core_set.update(range(start, end + 1))
+                            else:
+                                core_set.update(range(end, start + 1))
+                        else:
+                            try:
+                                core_set.add(int(part))
+                            except ValueError:
+                                continue
+                    if not core_set:
+                        continue
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1054,15 +1054,15 @@ if $run_pcm_power; then
   export RDT_IFACE=OS
 
   if [[ ${MBM_AVAILABLE} -eq 1 ]]; then
-    PQOS_GROUPS="mbt:[${WORKLOAD_CPU}]"
+    PQOS_GROUPS="all:${WORKLOAD_CPU}"
     if [[ -n ${OTHERS} ]]; then
-      PQOS_GROUPS="${PQOS_GROUPS};mbt:[${OTHERS}]"
+      PQOS_GROUPS="${PQOS_GROUPS};all:${OTHERS}"
     fi
     printf -v PQOS_CMD "taskset -c %s pqos -I -u csv -o %q -i %s -m %q" \
       "${TOOLS_CPU}" "${RESULT_PREFIX}_pqos.csv" "${PQOS_INTERVAL_TICKS}" "${PQOS_GROUPS}"
     {
       printf '[pqos] cmd: %s\n' "${PQOS_CMD}"
-      printf '[pqos] groups: workload=[%s] others=[%s]\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
+      printf '[pqos] groups: workload=%s others=%s\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
     } >>"${PQOS_LOG}"
     if spawn_sidecar "pqos" "${PQOS_CMD}" "${PQOS_LOG}" PQOS_PID; then
       PQOS_START_TS=$(date +%s)
@@ -1589,6 +1589,8 @@ def main():
                     if math.isnan(mbt_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
+                    core_clean = core_clean.replace("[", "").replace("]", "")
+                    core_clean = core_clean.replace("{", "").replace("}", "")
                     if not core_clean:
                         continue
                     core_set = set()
@@ -1596,10 +1598,28 @@ def main():
                         part = part.strip()
                         if not part:
                             continue
-                        try:
-                            core_set.add(int(part))
-                        except ValueError:
+                        if ":" in part:
+                            part = part.split(":", 1)[1].strip()
+                        if not part:
                             continue
+                        if "-" in part:
+                            start_str, end_str = part.split("-", 1)
+                            try:
+                                start = int(start_str.strip())
+                                end = int(end_str.strip())
+                            except ValueError:
+                                continue
+                            if start <= end:
+                                core_set.update(range(start, end + 1))
+                            else:
+                                core_set.update(range(end, start + 1))
+                        else:
+                            try:
+                                core_set.add(int(part))
+                            except ValueError:
+                                continue
+                    if not core_set:
+                        continue
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1054,15 +1054,15 @@ if $run_pcm_power; then
   export RDT_IFACE=OS
 
   if [[ ${MBM_AVAILABLE} -eq 1 ]]; then
-    PQOS_GROUPS="mbt:[${WORKLOAD_CPU}]"
+    PQOS_GROUPS="all:${WORKLOAD_CPU}"
     if [[ -n ${OTHERS} ]]; then
-      PQOS_GROUPS="${PQOS_GROUPS};mbt:[${OTHERS}]"
+      PQOS_GROUPS="${PQOS_GROUPS};all:${OTHERS}"
     fi
     printf -v PQOS_CMD "taskset -c %s pqos -I -u csv -o %q -i %s -m %q" \
       "${TOOLS_CPU}" "${RESULT_PREFIX}_pqos.csv" "${PQOS_INTERVAL_TICKS}" "${PQOS_GROUPS}"
     {
       printf '[pqos] cmd: %s\n' "${PQOS_CMD}"
-      printf '[pqos] groups: workload=[%s] others=[%s]\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
+      printf '[pqos] groups: workload=%s others=%s\n' "${WORKLOAD_CPU}" "${OTHERS:-<none>}"
     } >>"${PQOS_LOG}"
     if spawn_sidecar "pqos" "${PQOS_CMD}" "${PQOS_LOG}" PQOS_PID; then
       PQOS_START_TS=$(date +%s)
@@ -1589,6 +1589,8 @@ def main():
                     if math.isnan(mbt_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
+                    core_clean = core_clean.replace("[", "").replace("]", "")
+                    core_clean = core_clean.replace("{", "").replace("}", "")
                     if not core_clean:
                         continue
                     core_set = set()
@@ -1596,10 +1598,28 @@ def main():
                         part = part.strip()
                         if not part:
                             continue
-                        try:
-                            core_set.add(int(part))
-                        except ValueError:
+                        if ":" in part:
+                            part = part.split(":", 1)[1].strip()
+                        if not part:
                             continue
+                        if "-" in part:
+                            start_str, end_str = part.split("-", 1)
+                            try:
+                                start = int(start_str.strip())
+                                end = int(end_str.strip())
+                            except ValueError:
+                                continue
+                            if start <= end:
+                                core_set.update(range(start, end + 1))
+                            else:
+                                core_set.update(range(end, start + 1))
+                        else:
+                            try:
+                                core_set.add(int(part))
+                            except ValueError:
+                                continue
+                    if not core_set:
+                        continue
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),


### PR DESCRIPTION
## Summary
- switch pqos monitoring groups in all run scripts to the legacy `all:` syntax without brackets for consistent CSV output
- harden pqos CSV parsing to tolerate prefixed/ranged core identifiers when collecting MBT samples

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68def1a53988832c868b2a9a8380895e