### PR TITLE
Fix pqos DRAM attribution to use MBL totals

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1319,26 +1319,26 @@ def pqos_entries_for_window(times, entries, window_start, window_end, interval):
     return selected
 
 
-def average_mbt_components(samples, workload_core_set):
+def average_mbl_components(samples, workload_core_set):
     if not samples:
         return 0.0, 0.0, 0
     core_total = 0.0
-    others_total = 0.0
+    bandwidth_total = 0.0
     count = 0
     for sample in samples:
         core_sum = 0.0
-        others_sum = 0.0
+        total_sum = 0.0
         for entry in sample.get("rows", []):
+            value = max(entry.get("mbl", 0.0), 0.0)
+            total_sum += value
             if entry["core"] == workload_core_set:
-                core_sum += entry["mbt"]
-            else:
-                others_sum += entry["mbt"]
-        core_total += max(core_sum, 0.0)
-        others_total += max(others_sum, 0.0)
+                core_sum += value
+        core_total += core_sum
+        bandwidth_total += total_sum
         count += 1
     if count == 0:
         return 0.0, 0.0, 0
-    return core_total / count, others_total / count, count
+    return core_total / count, bandwidth_total / count, count
 
 
 def main():
@@ -1523,26 +1523,26 @@ def main():
                     turbostat_blocks.append({"tau": tau, "rows": block_rows})
 
     pqos_entries_raw = []
-    mbt_field = None
+    mbl_field = None
     if pqos_path.exists():
         with open(pqos_path, newline="") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames or []
             for name in fieldnames:
                 lower = name.lower()
-                if "mbt" in lower and "/s" in lower:
-                    mbt_field = name
+                if "mbl" in lower and "/s" in lower:
+                    mbl_field = name
                     break
-            if mbt_field is None:
-                warn("pqos MBT column not found; skipping pqos attribution")
+            if mbl_field is None:
+                error("pqos MBL column not found; skipping pqos attribution")
             else:
                 for row in reader:
                     time_value = row.get("Time")
                     core_value = row.get("Core")
                     if time_value is None or core_value is None:
                         continue
-                    mbt_value = safe_float(row.get(mbt_field))
-                    if math.isnan(mbt_value):
+                    mbl_value = safe_float(row.get(mbl_field))
+                    if math.isnan(mbl_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
                     core_clean = core_clean.replace("[", "").replace("]", "")
@@ -1579,7 +1579,7 @@ def main():
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),
-                        "mbt": max(mbt_value, 0.0),
+                        "mbl": max(mbl_value, 0.0),
                     })
 
     pqos_samples = []
@@ -1682,11 +1682,11 @@ def main():
                 window_end,
                 PQOS_INTERVAL_SEC,
             )
-            mbt_core = 0.0
-            mbt_others = 0.0
+            mbl_core = 0.0
+            mbl_total = 0.0
             if selected_samples:
                 pqos_in_window += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     selected_samples, workload_core_set
                 )
             else:
@@ -1706,11 +1706,11 @@ def main():
                     pqos_in_window += 1
                 elif near:
                     pqos_near += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     [sample], workload_core_set
                 )
-            mbt_all = max(mbt_core, 0.0) + max(mbt_others, 0.0)
-            fraction = clamp01(mbt_core / mbt_all) if mbt_all > EPS else 0.0
+            total_bandwidth = max(mbl_total, 0.0)
+            fraction = clamp01(mbl_core / total_bandwidth) if total_bandwidth > EPS else 0.0
             dram_raw.append(fraction * dram_powers[idx])
 
     log(f"alignment turbostat: in_window={ts_in_window}, near={ts_near}, miss={ts_miss}")

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1343,26 +1343,26 @@ def pqos_entries_for_window(times, entries, window_start, window_end, interval):
     return selected
 
 
-def average_mbt_components(samples, workload_core_set):
+def average_mbl_components(samples, workload_core_set):
     if not samples:
         return 0.0, 0.0, 0
     core_total = 0.0
-    others_total = 0.0
+    bandwidth_total = 0.0
     count = 0
     for sample in samples:
         core_sum = 0.0
-        others_sum = 0.0
+        total_sum = 0.0
         for entry in sample.get("rows", []):
+            value = max(entry.get("mbl", 0.0), 0.0)
+            total_sum += value
             if entry["core"] == workload_core_set:
-                core_sum += entry["mbt"]
-            else:
-                others_sum += entry["mbt"]
-        core_total += max(core_sum, 0.0)
-        others_total += max(others_sum, 0.0)
+                core_sum += value
+        core_total += core_sum
+        bandwidth_total += total_sum
         count += 1
     if count == 0:
         return 0.0, 0.0, 0
-    return core_total / count, others_total / count, count
+    return core_total / count, bandwidth_total / count, count
 
 
 def main():
@@ -1547,26 +1547,26 @@ def main():
                     turbostat_blocks.append({"tau": tau, "rows": block_rows})
 
     pqos_entries_raw = []
-    mbt_field = None
+    mbl_field = None
     if pqos_path.exists():
         with open(pqos_path, newline="") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames or []
             for name in fieldnames:
                 lower = name.lower()
-                if "mbt" in lower and "/s" in lower:
-                    mbt_field = name
+                if "mbl" in lower and "/s" in lower:
+                    mbl_field = name
                     break
-            if mbt_field is None:
-                warn("pqos MBT column not found; skipping pqos attribution")
+            if mbl_field is None:
+                error("pqos MBL column not found; skipping pqos attribution")
             else:
                 for row in reader:
                     time_value = row.get("Time")
                     core_value = row.get("Core")
                     if time_value is None or core_value is None:
                         continue
-                    mbt_value = safe_float(row.get(mbt_field))
-                    if math.isnan(mbt_value):
+                    mbl_value = safe_float(row.get(mbl_field))
+                    if math.isnan(mbl_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
                     core_clean = core_clean.replace("[", "").replace("]", "")
@@ -1603,7 +1603,7 @@ def main():
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),
-                        "mbt": max(mbt_value, 0.0),
+                        "mbl": max(mbl_value, 0.0),
                     })
 
     pqos_samples = []
@@ -1706,11 +1706,11 @@ def main():
                 window_end,
                 PQOS_INTERVAL_SEC,
             )
-            mbt_core = 0.0
-            mbt_others = 0.0
+            mbl_core = 0.0
+            mbl_total = 0.0
             if selected_samples:
                 pqos_in_window += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     selected_samples, workload_core_set
                 )
             else:
@@ -1730,11 +1730,11 @@ def main():
                     pqos_in_window += 1
                 elif near:
                     pqos_near += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     [sample], workload_core_set
                 )
-            mbt_all = max(mbt_core, 0.0) + max(mbt_others, 0.0)
-            fraction = clamp01(mbt_core / mbt_all) if mbt_all > EPS else 0.0
+            total_bandwidth = max(mbl_total, 0.0)
+            fraction = clamp01(mbl_core / total_bandwidth) if total_bandwidth > EPS else 0.0
             dram_raw.append(fraction * dram_powers[idx])
 
     log(f"alignment turbostat: in_window={ts_in_window}, near={ts_near}, miss={ts_miss}")

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1363,26 +1363,26 @@ def pqos_entries_for_window(times, entries, window_start, window_end, interval):
     return selected
 
 
-def average_mbt_components(samples, workload_core_set):
+def average_mbl_components(samples, workload_core_set):
     if not samples:
         return 0.0, 0.0, 0
     core_total = 0.0
-    others_total = 0.0
+    bandwidth_total = 0.0
     count = 0
     for sample in samples:
         core_sum = 0.0
-        others_sum = 0.0
+        total_sum = 0.0
         for entry in sample.get("rows", []):
+            value = max(entry.get("mbl", 0.0), 0.0)
+            total_sum += value
             if entry["core"] == workload_core_set:
-                core_sum += entry["mbt"]
-            else:
-                others_sum += entry["mbt"]
-        core_total += max(core_sum, 0.0)
-        others_total += max(others_sum, 0.0)
+                core_sum += value
+        core_total += core_sum
+        bandwidth_total += total_sum
         count += 1
     if count == 0:
         return 0.0, 0.0, 0
-    return core_total / count, others_total / count, count
+    return core_total / count, bandwidth_total / count, count
 
 
 def main():
@@ -1567,26 +1567,26 @@ def main():
                     turbostat_blocks.append({"tau": tau, "rows": block_rows})
 
     pqos_entries_raw = []
-    mbt_field = None
+    mbl_field = None
     if pqos_path.exists():
         with open(pqos_path, newline="") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames or []
             for name in fieldnames:
                 lower = name.lower()
-                if "mbt" in lower and "/s" in lower:
-                    mbt_field = name
+                if "mbl" in lower and "/s" in lower:
+                    mbl_field = name
                     break
-            if mbt_field is None:
-                warn("pqos MBT column not found; skipping pqos attribution")
+            if mbl_field is None:
+                error("pqos MBL column not found; skipping pqos attribution")
             else:
                 for row in reader:
                     time_value = row.get("Time")
                     core_value = row.get("Core")
                     if time_value is None or core_value is None:
                         continue
-                    mbt_value = safe_float(row.get(mbt_field))
-                    if math.isnan(mbt_value):
+                    mbl_value = safe_float(row.get(mbl_field))
+                    if math.isnan(mbl_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
                     core_clean = core_clean.replace("[", "").replace("]", "")
@@ -1623,7 +1623,7 @@ def main():
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),
-                        "mbt": max(mbt_value, 0.0),
+                        "mbl": max(mbl_value, 0.0),
                     })
 
     pqos_samples = []
@@ -1726,11 +1726,11 @@ def main():
                 window_end,
                 PQOS_INTERVAL_SEC,
             )
-            mbt_core = 0.0
-            mbt_others = 0.0
+            mbl_core = 0.0
+            mbl_total = 0.0
             if selected_samples:
                 pqos_in_window += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     selected_samples, workload_core_set
                 )
             else:
@@ -1750,11 +1750,11 @@ def main():
                     pqos_in_window += 1
                 elif near:
                     pqos_near += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     [sample], workload_core_set
                 )
-            mbt_all = max(mbt_core, 0.0) + max(mbt_others, 0.0)
-            fraction = clamp01(mbt_core / mbt_all) if mbt_all > EPS else 0.0
+            total_bandwidth = max(mbl_total, 0.0)
+            fraction = clamp01(mbl_core / total_bandwidth) if total_bandwidth > EPS else 0.0
             dram_raw.append(fraction * dram_powers[idx])
 
     log(f"alignment turbostat: in_window={ts_in_window}, near={ts_near}, miss={ts_miss}")

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1363,26 +1363,26 @@ def pqos_entries_for_window(times, entries, window_start, window_end, interval):
     return selected
 
 
-def average_mbt_components(samples, workload_core_set):
+def average_mbl_components(samples, workload_core_set):
     if not samples:
         return 0.0, 0.0, 0
     core_total = 0.0
-    others_total = 0.0
+    bandwidth_total = 0.0
     count = 0
     for sample in samples:
         core_sum = 0.0
-        others_sum = 0.0
+        total_sum = 0.0
         for entry in sample.get("rows", []):
+            value = max(entry.get("mbl", 0.0), 0.0)
+            total_sum += value
             if entry["core"] == workload_core_set:
-                core_sum += entry["mbt"]
-            else:
-                others_sum += entry["mbt"]
-        core_total += max(core_sum, 0.0)
-        others_total += max(others_sum, 0.0)
+                core_sum += value
+        core_total += core_sum
+        bandwidth_total += total_sum
         count += 1
     if count == 0:
         return 0.0, 0.0, 0
-    return core_total / count, others_total / count, count
+    return core_total / count, bandwidth_total / count, count
 
 
 def main():
@@ -1567,26 +1567,26 @@ def main():
                     turbostat_blocks.append({"tau": tau, "rows": block_rows})
 
     pqos_entries_raw = []
-    mbt_field = None
+    mbl_field = None
     if pqos_path.exists():
         with open(pqos_path, newline="") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames or []
             for name in fieldnames:
                 lower = name.lower()
-                if "mbt" in lower and "/s" in lower:
-                    mbt_field = name
+                if "mbl" in lower and "/s" in lower:
+                    mbl_field = name
                     break
-            if mbt_field is None:
-                warn("pqos MBT column not found; skipping pqos attribution")
+            if mbl_field is None:
+                error("pqos MBL column not found; skipping pqos attribution")
             else:
                 for row in reader:
                     time_value = row.get("Time")
                     core_value = row.get("Core")
                     if time_value is None or core_value is None:
                         continue
-                    mbt_value = safe_float(row.get(mbt_field))
-                    if math.isnan(mbt_value):
+                    mbl_value = safe_float(row.get(mbl_field))
+                    if math.isnan(mbl_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
                     core_clean = core_clean.replace("[", "").replace("]", "")
@@ -1623,7 +1623,7 @@ def main():
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),
-                        "mbt": max(mbt_value, 0.0),
+                        "mbl": max(mbl_value, 0.0),
                     })
 
     pqos_samples = []
@@ -1726,11 +1726,11 @@ def main():
                 window_end,
                 PQOS_INTERVAL_SEC,
             )
-            mbt_core = 0.0
-            mbt_others = 0.0
+            mbl_core = 0.0
+            mbl_total = 0.0
             if selected_samples:
                 pqos_in_window += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     selected_samples, workload_core_set
                 )
             else:
@@ -1750,11 +1750,11 @@ def main():
                     pqos_in_window += 1
                 elif near:
                     pqos_near += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     [sample], workload_core_set
                 )
-            mbt_all = max(mbt_core, 0.0) + max(mbt_others, 0.0)
-            fraction = clamp01(mbt_core / mbt_all) if mbt_all > EPS else 0.0
+            total_bandwidth = max(mbl_total, 0.0)
+            fraction = clamp01(mbl_core / total_bandwidth) if total_bandwidth > EPS else 0.0
             dram_raw.append(fraction * dram_powers[idx])
 
     log(f"alignment turbostat: in_window={ts_in_window}, near={ts_near}, miss={ts_miss}")

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1363,26 +1363,26 @@ def pqos_entries_for_window(times, entries, window_start, window_end, interval):
     return selected
 
 
-def average_mbt_components(samples, workload_core_set):
+def average_mbl_components(samples, workload_core_set):
     if not samples:
         return 0.0, 0.0, 0
     core_total = 0.0
-    others_total = 0.0
+    bandwidth_total = 0.0
     count = 0
     for sample in samples:
         core_sum = 0.0
-        others_sum = 0.0
+        total_sum = 0.0
         for entry in sample.get("rows", []):
+            value = max(entry.get("mbl", 0.0), 0.0)
+            total_sum += value
             if entry["core"] == workload_core_set:
-                core_sum += entry["mbt"]
-            else:
-                others_sum += entry["mbt"]
-        core_total += max(core_sum, 0.0)
-        others_total += max(others_sum, 0.0)
+                core_sum += value
+        core_total += core_sum
+        bandwidth_total += total_sum
         count += 1
     if count == 0:
         return 0.0, 0.0, 0
-    return core_total / count, others_total / count, count
+    return core_total / count, bandwidth_total / count, count
 
 
 def main():
@@ -1567,26 +1567,26 @@ def main():
                     turbostat_blocks.append({"tau": tau, "rows": block_rows})
 
     pqos_entries_raw = []
-    mbt_field = None
+    mbl_field = None
     if pqos_path.exists():
         with open(pqos_path, newline="") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames or []
             for name in fieldnames:
                 lower = name.lower()
-                if "mbt" in lower and "/s" in lower:
-                    mbt_field = name
+                if "mbl" in lower and "/s" in lower:
+                    mbl_field = name
                     break
-            if mbt_field is None:
-                warn("pqos MBT column not found; skipping pqos attribution")
+            if mbl_field is None:
+                error("pqos MBL column not found; skipping pqos attribution")
             else:
                 for row in reader:
                     time_value = row.get("Time")
                     core_value = row.get("Core")
                     if time_value is None or core_value is None:
                         continue
-                    mbt_value = safe_float(row.get(mbt_field))
-                    if math.isnan(mbt_value):
+                    mbl_value = safe_float(row.get(mbl_field))
+                    if math.isnan(mbl_value):
                         continue
                     core_clean = core_value.replace('"', "").strip()
                     core_clean = core_clean.replace("[", "").replace("]", "")
@@ -1623,7 +1623,7 @@ def main():
                     pqos_entries_raw.append({
                         "time": time_value.strip(),
                         "core": frozenset(core_set),
-                        "mbt": max(mbt_value, 0.0),
+                        "mbl": max(mbl_value, 0.0),
                     })
 
     pqos_samples = []
@@ -1726,11 +1726,11 @@ def main():
                 window_end,
                 PQOS_INTERVAL_SEC,
             )
-            mbt_core = 0.0
-            mbt_others = 0.0
+            mbl_core = 0.0
+            mbl_total = 0.0
             if selected_samples:
                 pqos_in_window += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     selected_samples, workload_core_set
                 )
             else:
@@ -1750,11 +1750,11 @@ def main():
                     pqos_in_window += 1
                 elif near:
                     pqos_near += 1
-                mbt_core, mbt_others, _ = average_mbt_components(
+                mbl_core, mbl_total, _ = average_mbl_components(
                     [sample], workload_core_set
                 )
-            mbt_all = max(mbt_core, 0.0) + max(mbt_others, 0.0)
-            fraction = clamp01(mbt_core / mbt_all) if mbt_all > EPS else 0.0
+            total_bandwidth = max(mbl_total, 0.0)
+            fraction = clamp01(mbl_core / total_bandwidth) if total_bandwidth > EPS else 0.0
             dram_raw.append(fraction * dram_powers[idx])
 
     log(f"alignment turbostat: in_window={ts_in_window}, near={ts_near}, miss={ts_miss}")


### PR DESCRIPTION
## Summary
- parse pqos profiler CSVs using the MBL bandwidth column and keep runs going even when it is missing
- sum per-core MBL readings to compute the total bandwidth denominator when deriving DRAM attribution

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df048f8fb4832cbf0a220174a866b7