### PR TITLE
Improve Maya workload error reporting

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1917,8 +1917,15 @@ if $run_maya; then
       cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
     } || true
 
+    # Ensure workload log exists before launching
+    : > /local/data/results/id_1_maya.log
+
     # Run workload on CPU 6
-    taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1 || true
+    workload_status=0
+    if ! taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1; then
+      workload_status=$?
+      printf '[error] id_1/main exited with status %d\n' "$workload_status" >> /local/data/results/id_1_maya.log
+    fi
 
     # Idempotent teardown with escalation and reap
     for sig in TERM KILL; do
@@ -1929,7 +1936,18 @@ if $run_maya; then
       kill -0 "$MAYA_PID" 2>/dev/null || break
     done
     wait "$MAYA_PID" 2>/dev/null || true
+    exit "$workload_status"
   '
+  maya_status=$?
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[ERROR] Maya execution wrapper exited with status $maya_status"
+    exit "$maya_status"
+  fi
+  if [[ ! -s /local/data/results/id_1_maya.log ]]; then
+    echo "[ERROR] Maya workload log /local/data/results/id_1_maya.log is missing or empty"
+    maya_status=1
+    exit "$maya_status"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1967,11 +1967,18 @@ if $run_maya; then
     cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
   } || true
 
+  # Ensure workload log exists before launching
+  : > /local/data/results/id_20_3gram_llm_maya.log
+
   # Run workload on CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+  workload_status=0
+  if ! taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
     --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1 || true
+    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1; then
+    workload_status=$?
+    printf '[error] llm_model_run.py exited with status %d\n' "$workload_status" >> /local/data/results/id_20_3gram_llm_maya.log
+  fi
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1982,7 +1989,18 @@ if $run_maya; then
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
   wait "$MAYA_PID" 2>/dev/null || true
+  exit "$workload_status"
   '
+  maya_status=$?
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[ERROR] Maya execution wrapper exited with status $maya_status"
+    exit "$maya_status"
+  fi
+  if [[ ! -s /local/data/results/id_20_3gram_llm_maya.log ]]; then
+    echo "[ERROR] Maya workload log /local/data/results/id_20_3gram_llm_maya.log is missing or empty"
+    maya_status=1
+    exit "$maya_status"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1967,11 +1967,18 @@ if $run_maya; then
     cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
   } || true
 
+  # Ensure workload log exists before launching
+  : > /local/data/results/id_20_3gram_rnn_maya.log
+
   # Run workload on CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+  workload_status=0
+  if ! taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
     --datasetPath=/local/data/ptDecoder_ctc \
     --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1 || true
+    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1; then
+    workload_status=$?
+    printf '[error] rnn_run.py exited with status %d\n' "$workload_status" >> /local/data/results/id_20_3gram_rnn_maya.log
+  fi
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1982,7 +1989,18 @@ if $run_maya; then
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
   wait "$MAYA_PID" 2>/dev/null || true
+  exit "$workload_status"
   '
+  maya_status=$?
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[ERROR] Maya execution wrapper exited with status $maya_status"
+    exit "$maya_status"
+  fi
+  if [[ ! -s /local/data/results/id_20_3gram_rnn_maya.log ]]; then
+    echo "[ERROR] Maya workload log /local/data/results/id_20_3gram_rnn_maya.log is missing or empty"
+    maya_status=1
+    exit "$maya_status"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -1928,9 +1928,16 @@ if $run_maya; then
       cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
     } || true
 
+    # Ensure workload log exists before launching
+    : > /local/data/results/id_3_maya.log
+
     # Run workload on CPU 6
-    taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_maya.csv \
-      >> /local/data/results/id_3_maya.log 2>&1 || true
+    workload_status=0
+    if ! taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_maya.csv \
+      >> /local/data/results/id_3_maya.log 2>&1; then
+      workload_status=$?
+      printf '[error] benchmark-lossless.py exited with status %d\n' "$workload_status" >> /local/data/results/id_3_maya.log
+    fi
 
     # Idempotent teardown with escalation and reap
     for sig in TERM KILL; do
@@ -1941,7 +1948,18 @@ if $run_maya; then
       kill -0 "$MAYA_PID" 2>/dev/null || break
     done
     wait "$MAYA_PID" 2>/dev/null || true
+    exit "$workload_status"
   '
+  maya_status=$?
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[ERROR] Maya execution wrapper exited with status $maya_status"
+    exit "$maya_status"
+  fi
+  if [[ ! -s /local/data/results/id_3_maya.log ]]; then
+    echo "[ERROR] Maya workload log /local/data/results/id_3_maya.log is missing or empty"
+    maya_status=1
+    exit "$maya_status"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))


### PR DESCRIPTION
## Summary
- pre-create Maya workload logs and capture non-zero exit codes in each Maya runner
- propagate workload exit status through the shield wrapper and append explicit error messages
- fail fast in the main script when Maya execution fails or its log file is missing/empty

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00e0d1988832cb131cdeb52dcbbcb