### PR TITLE
Add tmux relaunch guard to all startup scripts

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -2,6 +2,17 @@
 set -e
 
 ################################################################################
+### Initialize tmux session when launched outside tmux
+################################################################################
+
+if [[ -z ${TMUX:-} ]]; then
+  session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
+  echo "Running outside tmux. Starting tmux session '$session_name'."
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
+fi
+
+################################################################################
 
 ### Log keeping
 

--- a/scripts/startup_1.sh
+++ b/scripts/startup_1.sh
@@ -2,6 +2,17 @@
 set -e
 
 ################################################################################
+### Initialize tmux session when launched outside tmux
+################################################################################
+
+if [[ -z ${TMUX:-} ]]; then
+  session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
+  echo "Running outside tmux. Starting tmux session '$session_name'."
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
+fi
+
+################################################################################
 
 ### Log keeping
 

--- a/scripts/startup_13.sh
+++ b/scripts/startup_13.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+################################################################################
+### Initialize tmux session when launched outside tmux
+################################################################################
+
+if [[ -z ${TMUX:-} ]]; then
+  session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
+  echo "Running outside tmux. Starting tmux session '$session_name'."
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
+fi
+
 # Ensure required variables will be defined later in this script.
 required_vars=(USERNAME PASSWORD VPN_SERVER LICENSE_SERVER MLM_PORT)
 missing=()

--- a/scripts/startup_20_3gram.sh
+++ b/scripts/startup_20_3gram.sh
@@ -2,6 +2,17 @@
 set -e
 
 ################################################################################
+### Initialize tmux session when launched outside tmux
+################################################################################
+
+if [[ -z ${TMUX:-} ]]; then
+  session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
+  echo "Running outside tmux. Starting tmux session '$session_name'."
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
+fi
+
+################################################################################
 
 ### Log keeping
 

--- a/scripts/startup_3.sh
+++ b/scripts/startup_3.sh
@@ -2,6 +2,17 @@
 set -e
 
 ################################################################################
+### Initialize tmux session when launched outside tmux
+################################################################################
+
+if [[ -z ${TMUX:-} ]]; then
+  session_name="$(basename "$0" .sh)"
+  script_path="$(readlink -f "$0")"
+  echo "Running outside tmux. Starting tmux session '$session_name'."
+  exec tmux new-session -s "$session_name" "$script_path" "$@"
+fi
+
+################################################################################
 
 ### Log keeping
 


### PR DESCRIPTION
## Summary
- add the same tmux relaunch wrapper used by workload run scripts to each startup script
- ensure startup scripts across workloads automatically re-exec inside tmux sessions when not already in one

## Testing
- not run (startup scripts only)

------
https://chatgpt.com/codex/tasks/task_e_68e02add8794832c988940f0383c874e