### PR TITLE
Improve Maya diagnostics in run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1896,12 +1896,18 @@ if $run_maya; then
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
+  maya_output_txt="/local/data/results/id_1_maya.txt"
+  maya_output_log="/local/data/results/id_1_maya.log"
+  maya_status_file="/local/data/results/id_1_maya.status"
+  export MAYA_OUTPUT_TXT="$maya_output_txt"
+  export MAYA_OUTPUT_LOG="$maya_output_log"
+  export MAYA_STATUS_FILE="$maya_status_file"
   sudo -E cset shield --exec -- bash -lc '
     set -euo pipefail
 
     # Start Maya on CPU 5 in background; capture PID immediately
     taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-      > /local/data/results/id_1_maya.txt 2>&1 &
+      > "$MAYA_OUTPUT_TXT" 2>&1 &
     MAYA_PID=$!
 
     # Small startup delay to avoid cold-start hiccups
@@ -1918,7 +1924,7 @@ if $run_maya; then
     } || true
 
     # Run workload on CPU 6
-    taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1 || true
+    taskset -c 6 /local/bci_code/id_1/main >> "$MAYA_OUTPUT_LOG" 2>&1 || true
 
     # Idempotent teardown with escalation and reap
     for sig in TERM KILL; do
@@ -1928,14 +1934,44 @@ if $run_maya; then
       fi
       kill -0 "$MAYA_PID" 2>/dev/null || break
     done
-    wait "$MAYA_PID" 2>/dev/null || true
+    set +e
+    wait "$MAYA_PID"
+    maya_status=$?
+    set -e
+    echo "[maya] exit status=${maya_status}"
+    if [[ $maya_status -ne 0 ]]; then
+      echo "[maya] profiler exited with status ${maya_status}"
+      if [[ -s "$MAYA_OUTPUT_TXT" ]]; then
+        echo "[maya] showing last 20 lines of $MAYA_OUTPUT_TXT"
+        tail -n 20 "$MAYA_OUTPUT_TXT" || true
+      else
+        echo "[maya] log file $MAYA_OUTPUT_TXT missing or empty"
+      fi
+    fi
+    echo "${maya_status}" > "$MAYA_STATUS_FILE" || true
   '
+  unset MAYA_STATUS_FILE
+  unset MAYA_OUTPUT_TXT
+  unset MAYA_OUTPUT_LOG
+  maya_status="unknown"
+  if [[ -f "$maya_status_file" ]]; then
+    maya_status="$(<"$maya_status_file")"
+    rm -f "$maya_status_file"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_maya.log
+  {
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+    echo "Maya exit status: ${maya_status}"
+  } > /local/data/results/done_maya.log
+  if [[ $maya_status =~ ^-?[0-9]+$ && $maya_status -ne 0 ]]; then
+    echo "Warning: Maya exited with status ${maya_status}. See log output above."
+  elif [[ $maya_status == "unknown" ]]; then
+    echo "Warning: Maya exit status is unknown (status file missing)."
+  fi
   log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya exit status: ${maya_status}"
 fi
 echo
 

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1942,6 +1942,12 @@ if $run_maya; then
   maya_start=$(date +%s)
 
   # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
+  maya_output_txt="/local/data/results/id_20_3gram_llm_maya.txt"
+  maya_output_log="/local/data/results/id_20_3gram_llm_maya.log"
+  maya_status_file="/local/data/results/id_20_3gram_llm_maya.status"
+  export MAYA_OUTPUT_TXT="$maya_output_txt"
+  export MAYA_OUTPUT_LOG="$maya_output_log"
+  export MAYA_STATUS_FILE="$maya_status_file"
   sudo -E cset shield --exec -- bash -lc '
   set -euo pipefail
   source /local/tools/bci_env/bin/activate
@@ -1951,7 +1957,7 @@ if $run_maya; then
 
   # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
+    > "$MAYA_OUTPUT_TXT" 2>&1 &
   MAYA_PID=$!
 
   # Small startup delay to avoid cold-start hiccups
@@ -1971,7 +1977,7 @@ if $run_maya; then
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
     --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1 || true
+    >> "$MAYA_OUTPUT_LOG" 2>&1 || true
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1981,14 +1987,44 @@ if $run_maya; then
     fi
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
-  wait "$MAYA_PID" 2>/dev/null || true
+  set +e
+  wait "$MAYA_PID"
+  maya_status=$?
+  set -e
+  echo "[maya] exit status=${maya_status}"
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[maya] profiler exited with status ${maya_status}"
+    if [[ -s "$MAYA_OUTPUT_TXT" ]]; then
+      echo "[maya] showing last 20 lines of $MAYA_OUTPUT_TXT"
+      tail -n 20 "$MAYA_OUTPUT_TXT" || true
+    else
+      echo "[maya] log file $MAYA_OUTPUT_TXT missing or empty"
+    fi
+  fi
+  echo "${maya_status}" > "$MAYA_STATUS_FILE" || true
   '
+  unset MAYA_STATUS_FILE
+  unset MAYA_OUTPUT_TXT
+  unset MAYA_OUTPUT_LOG
+  maya_status="unknown"
+  if [[ -f "$maya_status_file" ]]; then
+    maya_status="$(<"$maya_status_file")"
+    rm -f "$maya_status_file"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_llm_maya.log
+  {
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+    echo "Maya exit status: ${maya_status}"
+  } > /local/data/results/done_llm_maya.log
+  if [[ $maya_status =~ ^-?[0-9]+$ && $maya_status -ne 0 ]]; then
+    echo "Warning: Maya exited with status ${maya_status}. See log output above."
+  elif [[ $maya_status == "unknown" ]]; then
+    echo "Warning: Maya exit status is unknown (status file missing)."
+  fi
   log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya exit status: ${maya_status}"
 fi
 echo
 

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1942,6 +1942,12 @@ if $run_maya; then
   maya_start=$(date +%s)
 
   # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
+  maya_output_txt="/local/data/results/id_20_3gram_lm_maya.txt"
+  maya_output_log="/local/data/results/id_20_3gram_lm_maya.log"
+  maya_status_file="/local/data/results/id_20_3gram_lm_maya.status"
+  export MAYA_OUTPUT_TXT="$maya_output_txt"
+  export MAYA_OUTPUT_LOG="$maya_output_log"
+  export MAYA_STATUS_FILE="$maya_status_file"
   sudo -E cset shield --exec -- bash -lc '
   set -euo pipefail
   source /local/tools/bci_env/bin/activate
@@ -1951,7 +1957,7 @@ if $run_maya; then
 
   # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
+    > "$MAYA_OUTPUT_TXT" 2>&1 &
   MAYA_PID=$!
 
   # Small startup delay to avoid cold-start hiccups
@@ -1971,7 +1977,7 @@ if $run_maya; then
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
     --lmDir=/local/data/languageModel/ \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1 || true
+    >> "$MAYA_OUTPUT_LOG" 2>&1 || true
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1981,14 +1987,44 @@ if $run_maya; then
     fi
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
-  wait "$MAYA_PID" 2>/dev/null || true
+  set +e
+  wait "$MAYA_PID"
+  maya_status=$?
+  set -e
+  echo "[maya] exit status=${maya_status}"
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[maya] profiler exited with status ${maya_status}"
+    if [[ -s "$MAYA_OUTPUT_TXT" ]]; then
+      echo "[maya] showing last 20 lines of $MAYA_OUTPUT_TXT"
+      tail -n 20 "$MAYA_OUTPUT_TXT" || true
+    else
+      echo "[maya] log file $MAYA_OUTPUT_TXT missing or empty"
+    fi
+  fi
+  echo "${maya_status}" > "$MAYA_STATUS_FILE" || true
   '
+  unset MAYA_STATUS_FILE
+  unset MAYA_OUTPUT_TXT
+  unset MAYA_OUTPUT_LOG
+  maya_status="unknown"
+  if [[ -f "$maya_status_file" ]]; then
+    maya_status="$(<"$maya_status_file")"
+    rm -f "$maya_status_file"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_lm_maya.log
+  {
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+    echo "Maya exit status: ${maya_status}"
+  } > /local/data/results/done_lm_maya.log
+  if [[ $maya_status =~ ^-?[0-9]+$ && $maya_status -ne 0 ]]; then
+    echo "Warning: Maya exited with status ${maya_status}. See log output above."
+  elif [[ $maya_status == "unknown" ]]; then
+    echo "Warning: Maya exit status is unknown (status file missing)."
+  fi
   log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya exit status: ${maya_status}"
 fi
 echo
 

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1942,6 +1942,12 @@ if $run_maya; then
   maya_start=$(date +%s)
 
   # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
+  maya_output_txt="/local/data/results/id_20_3gram_rnn_maya.txt"
+  maya_output_log="/local/data/results/id_20_3gram_rnn_maya.log"
+  maya_status_file="/local/data/results/id_20_3gram_rnn_maya.status"
+  export MAYA_OUTPUT_TXT="$maya_output_txt"
+  export MAYA_OUTPUT_LOG="$maya_output_log"
+  export MAYA_STATUS_FILE="$maya_status_file"
   sudo -E cset shield --exec -- bash -lc '
   set -euo pipefail
   source /local/tools/bci_env/bin/activate
@@ -1951,7 +1957,7 @@ if $run_maya; then
 
   # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
+    > "$MAYA_OUTPUT_TXT" 2>&1 &
   MAYA_PID=$!
 
   # Small startup delay to avoid cold-start hiccups
@@ -1971,7 +1977,7 @@ if $run_maya; then
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
     --datasetPath=/local/data/ptDecoder_ctc \
     --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1 || true
+    >> "$MAYA_OUTPUT_LOG" 2>&1 || true
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1981,14 +1987,44 @@ if $run_maya; then
     fi
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
-  wait "$MAYA_PID" 2>/dev/null || true
+  set +e
+  wait "$MAYA_PID"
+  maya_status=$?
+  set -e
+  echo "[maya] exit status=${maya_status}"
+  if [[ $maya_status -ne 0 ]]; then
+    echo "[maya] profiler exited with status ${maya_status}"
+    if [[ -s "$MAYA_OUTPUT_TXT" ]]; then
+      echo "[maya] showing last 20 lines of $MAYA_OUTPUT_TXT"
+      tail -n 20 "$MAYA_OUTPUT_TXT" || true
+    else
+      echo "[maya] log file $MAYA_OUTPUT_TXT missing or empty"
+    fi
+  fi
+  echo "${maya_status}" > "$MAYA_STATUS_FILE" || true
   '
+  unset MAYA_STATUS_FILE
+  unset MAYA_OUTPUT_TXT
+  unset MAYA_OUTPUT_LOG
+  maya_status="unknown"
+  if [[ -f "$maya_status_file" ]]; then
+    maya_status="$(<"$maya_status_file")"
+    rm -f "$maya_status_file"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_rnn_maya.log
+  {
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+    echo "Maya exit status: ${maya_status}"
+  } > /local/data/results/done_rnn_maya.log
+  if [[ $maya_status =~ ^-?[0-9]+$ && $maya_status -ne 0 ]]; then
+    echo "Warning: Maya exited with status ${maya_status}. See log output above."
+  elif [[ $maya_status == "unknown" ]]; then
+    echo "Warning: Maya exit status is unknown (status file missing)."
+  fi
   log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya exit status: ${maya_status}"
 fi
 echo
 

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -1906,13 +1906,19 @@ if $run_maya; then
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
+  maya_output_txt="/local/data/results/id_3_maya.txt"
+  maya_output_log="/local/data/results/id_3_maya.log"
+  maya_status_file="/local/data/results/id_3_maya.status"
+  export MAYA_OUTPUT_TXT="$maya_output_txt"
+  export MAYA_OUTPUT_LOG="$maya_output_log"
+  export MAYA_STATUS_FILE="$maya_status_file"
   sudo -E cset shield --exec -- bash -lc '
     set -euo pipefail
     source /local/tools/compression_env/bin/activate
 
     # Start Maya on CPU 5 in background; capture PID immediately
     taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-      > /local/data/results/id_3_maya.txt 2>&1 &
+      > "$MAYA_OUTPUT_TXT" 2>&1 &
     MAYA_PID=$!
 
     # Small startup delay to avoid cold-start hiccups
@@ -1930,7 +1936,7 @@ if $run_maya; then
 
     # Run workload on CPU 6
     taskset -c 6 /local/tools/compression_env/bin/python scripts/benchmark-lossless.py aind-np1 0.1s flac /local/data/results/workload_maya.csv \
-      >> /local/data/results/id_3_maya.log 2>&1 || true
+      >> "$MAYA_OUTPUT_LOG" 2>&1 || true
 
     # Idempotent teardown with escalation and reap
     for sig in TERM KILL; do
@@ -1940,14 +1946,44 @@ if $run_maya; then
       fi
       kill -0 "$MAYA_PID" 2>/dev/null || break
     done
-    wait "$MAYA_PID" 2>/dev/null || true
+    set +e
+    wait "$MAYA_PID"
+    maya_status=$?
+    set -e
+    echo "[maya] exit status=${maya_status}"
+    if [[ $maya_status -ne 0 ]]; then
+      echo "[maya] profiler exited with status ${maya_status}"
+      if [[ -s "$MAYA_OUTPUT_TXT" ]]; then
+        echo "[maya] showing last 20 lines of $MAYA_OUTPUT_TXT"
+        tail -n 20 "$MAYA_OUTPUT_TXT" || true
+      else
+        echo "[maya] log file $MAYA_OUTPUT_TXT missing or empty"
+      fi
+    fi
+    echo "${maya_status}" > "$MAYA_STATUS_FILE" || true
   '
+  unset MAYA_STATUS_FILE
+  unset MAYA_OUTPUT_TXT
+  unset MAYA_OUTPUT_LOG
+  maya_status="unknown"
+  if [[ -f "$maya_status_file" ]]; then
+    maya_status="$(<"$maya_status_file")"
+    rm -f "$maya_status_file"
+  fi
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
-  echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_maya.log
+  {
+    echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")"
+    echo "Maya exit status: ${maya_status}"
+  } > /local/data/results/done_maya.log
+  if [[ $maya_status =~ ^-?[0-9]+$ && $maya_status -ne 0 ]]; then
+    echo "Warning: Maya exited with status ${maya_status}. See log output above."
+  elif [[ $maya_status == "unknown" ]]; then
+    echo "Warning: Maya exit status is unknown (status file missing)."
+  fi
   log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya exit status: ${maya_status}"
 fi
 echo
 


### PR DESCRIPTION
## Summary
- capture Maya exit codes across all workload run scripts and surface them in run.log
- print the tail of Maya output when the profiler exits early or with errors to aid debugging
- persist the exit status in done logs while keeping existing scheduling and teardown behaviour unchanged

## Testing
- bash -n scripts/run_1.sh
- bash -n scripts/run_3.sh
- bash -n scripts/run_13.sh
- bash -n scripts/run_20_3gram_lm.sh
- bash -n scripts/run_20_3gram_llm.sh
- bash -n scripts/run_20_3gram_rnn.sh


------
https://chatgpt.com/codex/tasks/task_e_68e1a122aa18832c8aded85946a6f0a6