### PR TITLE
Improve Maya crash diagnostics in run scripts

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1899,13 +1899,22 @@ if $run_maya; then
   sudo -E cset shield --exec -- bash -lc '
     set -euo pipefail
 
+    maya_txt="/local/data/results/id_1_maya.txt"
+    maya_log="/local/data/results/id_1_maya.log"
+
     # Start Maya on CPU 5 in background; capture PID immediately
     taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-      > /local/data/results/id_1_maya.txt 2>&1 &
+      > "$maya_txt" 2>&1 &
     MAYA_PID=$!
 
     # Small startup delay to avoid cold-start hiccups
     sleep 1
+
+    if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+      echo "[ERROR] Maya exited before startup"
+      tail -n +1 "$maya_txt" || true
+      exit 1
+    fi
 
     # Portable verification (no 'ps ... cpuset')
     {
@@ -1918,7 +1927,13 @@ if $run_maya; then
     } || true
 
     # Run workload on CPU 6
-    taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1 || true
+    taskset -c 6 /local/bci_code/id_1/main >> "$maya_log" 2>&1 || true
+
+    if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+      echo "[ERROR] Maya exited during workload"
+      tail -n +1 "$maya_txt" || true
+      exit 1
+    fi
 
     # Idempotent teardown with escalation and reap
     for sig in TERM KILL; do
@@ -1928,7 +1943,22 @@ if $run_maya; then
       fi
       kill -0 "$MAYA_PID" 2>/dev/null || break
     done
-    wait "$MAYA_PID" 2>/dev/null || true
+    wait_status=0
+    if wait "$MAYA_PID" 2>/dev/null; then
+      wait_status=0
+    else
+      wait_status=$?
+    fi
+
+    case "$wait_status" in
+      0|137|143)
+        ;;
+      *)
+        echo "[ERROR] Maya exited with status $wait_status"
+        tail -n +1 "$maya_txt" || true
+        exit "$wait_status"
+        ;;
+    esac
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1926,13 +1926,22 @@ if $run_maya; then
     export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
     export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
 
+    maya_txt="/local/data/results/id_13_maya.txt"
+    maya_log="/local/data/results/id_13_maya.log"
+
     # Start Maya on CPU 5 in background; capture PID immediately
     taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-      > /local/data/results/id_13_maya.txt 2>&1 &
+      > "$maya_txt" 2>&1 &
     MAYA_PID=$!
 
     # Small startup delay to avoid cold-start hiccups
     sleep 1
+
+    if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+      echo "[ERROR] Maya exited before startup"
+      tail -n +1 "$maya_txt" || true
+      exit 1
+    fi
 
     # Portable verification (no 'ps ... cpuset')
     {
@@ -1948,7 +1957,13 @@ if $run_maya; then
     taskset -c 6 /local/tools/matlab/bin/matlab \
       -nodisplay -nosplash \
       -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
-      >> /local/data/results/id_13_maya.log 2>&1 || true
+      >> "$maya_log" 2>&1 || true
+
+    if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+      echo "[ERROR] Maya exited during workload"
+      tail -n +1 "$maya_txt" || true
+      exit 1
+    fi
 
     # Idempotent teardown with escalation and reap
     for sig in TERM KILL; do
@@ -1958,7 +1973,22 @@ if $run_maya; then
       fi
       kill -0 "$MAYA_PID" 2>/dev/null || break
     done
-    wait "$MAYA_PID" 2>/dev/null || true
+    wait_status=0
+    if wait "$MAYA_PID" 2>/dev/null; then
+      wait_status=0
+    else
+      wait_status=$?
+    fi
+
+    case "$wait_status" in
+      0|137|143)
+        ;;
+      *)
+        echo "[ERROR] Maya exited with status $wait_status"
+        tail -n +1 "$maya_txt" || true
+        exit "$wait_status"
+        ;;
+    esac
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1949,13 +1949,22 @@ if $run_maya; then
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
+  maya_txt="/local/data/results/id_20_3gram_llm_maya.txt"
+  maya_log="/local/data/results/id_20_3gram_llm_maya.log"
+
   # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
+    > "$maya_txt" 2>&1 &
   MAYA_PID=$!
 
   # Small startup delay to avoid cold-start hiccups
   sleep 1
+
+  if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+    echo "[ERROR] Maya exited before startup"
+    tail -n +1 "$maya_txt" || true
+    exit 1
+  fi
 
   # Portable verification (no 'ps ... cpuset')
   {
@@ -1971,7 +1980,13 @@ if $run_maya; then
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
     --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1 || true
+    >> "$maya_log" 2>&1 || true
+
+  if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+    echo "[ERROR] Maya exited during workload"
+    tail -n +1 "$maya_txt" || true
+    exit 1
+  fi
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1981,7 +1996,22 @@ if $run_maya; then
     fi
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
-  wait "$MAYA_PID" 2>/dev/null || true
+  wait_status=0
+  if wait "$MAYA_PID" 2>/dev/null; then
+    wait_status=0
+  else
+    wait_status=$?
+  fi
+
+  case "$wait_status" in
+    0|137|143)
+      ;;
+    *)
+      echo "[ERROR] Maya exited with status $wait_status"
+      tail -n +1 "$maya_txt" || true
+      exit "$wait_status"
+      ;;
+  esac
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1949,13 +1949,22 @@ if $run_maya; then
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
+  maya_txt="/local/data/results/id_20_3gram_lm_maya.txt"
+  maya_log="/local/data/results/id_20_3gram_lm_maya.log"
+
   # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
+    > "$maya_txt" 2>&1 &
   MAYA_PID=$!
 
   # Small startup delay to avoid cold-start hiccups
   sleep 1
+
+  if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+    echo "[ERROR] Maya exited before startup"
+    tail -n +1 "$maya_txt" || true
+    exit 1
+  fi
 
   # Portable verification (no 'ps ... cpuset')
   {
@@ -1971,7 +1980,13 @@ if $run_maya; then
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
     --lmDir=/local/data/languageModel/ \
     --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1 || true
+    >> "$maya_log" 2>&1 || true
+
+  if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+    echo "[ERROR] Maya exited during workload"
+    tail -n +1 "$maya_txt" || true
+    exit 1
+  fi
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1981,7 +1996,22 @@ if $run_maya; then
     fi
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
-  wait "$MAYA_PID" 2>/dev/null || true
+  wait_status=0
+  if wait "$MAYA_PID" 2>/dev/null; then
+    wait_status=0
+  else
+    wait_status=$?
+  fi
+
+  case "$wait_status" in
+    0|137|143)
+      ;;
+    *)
+      echo "[ERROR] Maya exited with status $wait_status"
+      tail -n +1 "$maya_txt" || true
+      exit "$wait_status"
+      ;;
+  esac
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1949,13 +1949,22 @@ if $run_maya; then
   . path.sh
   export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
+  maya_txt="/local/data/results/id_20_3gram_rnn_maya.txt"
+  maya_log="/local/data/results/id_20_3gram_rnn_maya.log"
+
   # Start Maya on CPU 5 in background; capture PID immediately
   taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
+    > "$maya_txt" 2>&1 &
   MAYA_PID=$!
 
   # Small startup delay to avoid cold-start hiccups
   sleep 1
+
+  if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+    echo "[ERROR] Maya exited before startup"
+    tail -n +1 "$maya_txt" || true
+    exit 1
+  fi
 
   # Portable verification (no 'ps ... cpuset')
   {
@@ -1971,7 +1980,13 @@ if $run_maya; then
   taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
     --datasetPath=/local/data/ptDecoder_ctc \
     --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1 || true
+    >> "$maya_log" 2>&1 || true
+
+  if ! kill -0 "$MAYA_PID" 2>/dev/null; then
+    echo "[ERROR] Maya exited during workload"
+    tail -n +1 "$maya_txt" || true
+    exit 1
+  fi
 
   # Idempotent teardown with escalation and reap
   for sig in TERM KILL; do
@@ -1981,7 +1996,22 @@ if $run_maya; then
     fi
     kill -0 "$MAYA_PID" 2>/dev/null || break
   done
-  wait "$MAYA_PID" 2>/dev/null || true
+  wait_status=0
+  if wait "$MAYA_PID" 2>/dev/null; then
+    wait_status=0
+  else
+    wait_status=$?
+  fi
+
+  case "$wait_status" in
+    0|137|143)
+      ;;
+    *)
+      echo "[ERROR] Maya exited with status $wait_status"
+      tail -n +1 "$maya_txt" || true
+      exit "$wait_status"
+      ;;
+  esac
   '
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"


### PR DESCRIPTION
## Summary
- hoist Maya text/log file paths into reusable shell variables across all Maya launch blocks
- add kill -0 guards before and after workload execution to surface early Maya failures and dump profiler output
- record Maya exit status, treating expected termination signals as success and reporting other codes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55e5e4758832c9f6801623ce73a46