### PR TITLE
Harden Maya profiler failure handling

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1896,45 +1896,110 @@ if $run_maya; then
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    set -euo pipefail
+  MAYA_TXT_PATH="${RESULT_PREFIX}_maya.txt"
+  MAYA_LOG_PATH="${RESULT_PREFIX}_maya.log"
+  MAYA_DONE_PATH="${OUTDIR}/done_maya.log"
+  maya_failed=false
+  maya_status=0
+  : > "$MAYA_LOG_PATH"
+  : > "$MAYA_TXT_PATH"
+  maya_subshell=$(cat <<'EOF'
+set -euo pipefail
 
-    # Start Maya on CPU 5 in background; capture PID immediately
-    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-      > /local/data/results/id_1_maya.txt 2>&1 &
-    MAYA_PID=$!
+exec >> "$MAYA_LOG_PATH" 2>&1
+echo "[INFO] Maya wrapper started at $(date '+%Y-%m-%d %H:%M:%S')"
 
-    # Small startup delay to avoid cold-start hiccups
-    sleep 1
+command -v /local/bci_code/tools/maya/Dist/Release/Maya >/dev/null || {
+  echo "[ERROR] Maya binary not found"
+  exit 127
+}
+test -x /local/bci_code/tools/maya/Dist/Release/Maya || {
+  echo "[ERROR] Maya not executable"
+  exit 126
+}
 
-    # Portable verification (no 'ps ... cpuset')
-    {
-      echo "[verify] maya pid=$MAYA_PID"
-      ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
-      taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
-      # cpuset/cgroup path (v1 or v2)
-      cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
-      cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
-    } || true
+# Start Maya on CPU 5 in background; capture PID immediately
+taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+  > "$MAYA_TXT_PATH" 2>&1 &
+MAYA_PID=$!
 
-    # Run workload on CPU 6
-    taskset -c 6 /local/bci_code/id_1/main >> /local/data/results/id_1_maya.log 2>&1 || true
+kill -0 "$MAYA_PID" 2>/dev/null || {
+  echo "[ERROR] Maya failed to start"
+  exit 1
+}
 
-    # Idempotent teardown with escalation and reap
-    for sig in TERM KILL; do
-      if kill -0 "$MAYA_PID" 2>/dev/null; then
-        kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
-        timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
-      fi
-      kill -0 "$MAYA_PID" 2>/dev/null || break
-    done
-    wait "$MAYA_PID" 2>/dev/null || true
-  '
+# Small startup delay to avoid cold-start hiccups
+sleep 1
+
+# Portable verification (no 'ps ... cpuset')
+{
+  echo "[verify] maya pid=$MAYA_PID"
+  ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+  taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+  # cpuset/cgroup path (v1 or v2)
+  cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+  cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+} || true
+
+workload_status=0
+# Run workload on CPU 6
+taskset -c 6 /local/bci_code/id_1/main >> "$MAYA_LOG_PATH" 2>&1 || workload_status=$?
+
+if (( workload_status != 0 )); then
+  echo "[WARN] Workload exited with status ${workload_status}"
+fi
+
+# Idempotent teardown with escalation and reap
+for sig in TERM KILL; do
+  if kill -0 "$MAYA_PID" 2>/dev/null; then
+    kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+    timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+  fi
+  kill -0 "$MAYA_PID" 2>/dev/null || break
+done
+
+set +e
+wait "$MAYA_PID"
+wait_status=$?
+set -e
+
+if (( wait_status != 0 )); then
+  {
+    echo "==================== MAYA FAILURE ===================="
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Exit code: ${wait_status}"
+    if [[ -s "$MAYA_TXT_PATH" ]]; then
+      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
+      cat "$MAYA_TXT_PATH"
+    else
+      echo "(${MAYA_TXT_PATH} missing or empty)"
+    fi
+    echo "===================================================="
+  } >> "$MAYA_LOG_PATH"
+fi
+
+exit "$wait_status"
+EOF
+)
+  {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') Launching Maya wrapper command:"
+    printf 'sudo -E cset shield --exec -- bash -lc %q\n' "$maya_subshell"
+  } >> "$MAYA_LOG_PATH"
+  if ! MAYA_TXT_PATH="$MAYA_TXT_PATH" MAYA_LOG_PATH="$MAYA_LOG_PATH" sudo -E cset shield --exec -- bash -lc "$maya_subshell" 2>>"$MAYA_LOG_PATH"; then
+    maya_failed=true
+    maya_status=$?
+  fi
+
+  if $maya_failed; then
+    echo "Maya profiling failed with status ${maya_status}. See ${MAYA_LOG_PATH} for details."
+    exit "$maya_status"
+  fi
+
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_maya.log
+    > "$MAYA_DONE_PATH"
   log_debug "Maya completed in ${maya_runtime}s"
 fi
 echo
@@ -2032,17 +2097,23 @@ echo
 ################################################################################
 
 if $run_maya; then
-  echo "Converting id_1_maya.txt → id_1_maya.csv"
-  log_debug "Converting Maya output to CSV"
-  awk '
-  {
-    for (i = 1; i <= NF; i++) {
-      printf "%s%s", $i, (i < NF ? "," : "")
+  if (( maya_status != 0 )); then
+    log_debug "Skipping Maya CSV conversion due to failure status ${maya_status}"
+  elif [[ ! -s "$MAYA_TXT_PATH" ]]; then
+    echo "[WARN] Maya output ${MAYA_TXT_PATH} is empty; skipping CSV conversion."
+  else
+    echo "Converting id_1_maya.txt → id_1_maya.csv"
+    log_debug "Converting Maya output to CSV"
+    awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        printf "%s%s", $i, (i < NF ? "," : "")
+      }
+      print ""
     }
-    print ""
-  }
-  ' /local/data/results/id_1_maya.txt > /local/data/results/id_1_maya.csv
-  log_debug "Maya CSV generated"
+    ' "$MAYA_TXT_PATH" > "${RESULT_PREFIX}_maya.csv"
+    log_debug "Maya CSV generated"
+  fi
 fi
 echo
 

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1920,51 +1920,116 @@ if $run_maya; then
   idle_wait
   echo "Maya profiling started at: $(timestamp)"
   maya_start=$(date +%s)
-  sudo -E cset shield --exec -- bash -lc '
-    set -euo pipefail
-    export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
-    export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
-    export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
+  MAYA_TXT_PATH="${RESULT_PREFIX}_maya.txt"
+  MAYA_LOG_PATH="${RESULT_PREFIX}_maya.log"
+  MAYA_DONE_PATH="${OUTDIR}/done_maya.log"
+  maya_failed=false
+  maya_status=0
+  : > "$MAYA_LOG_PATH"
+  : > "$MAYA_TXT_PATH"
+  maya_subshell=$(cat <<'EOF'
+set -euo pipefail
+export MLM_LICENSE_FILE="27000@mlm.ece.utoronto.ca"
+export LM_LICENSE_FILE="$MLM_LICENSE_FILE"
+export MATLAB_PREFDIR="/local/tools/matlab_prefs/R2024b"
 
-    # Start Maya on CPU 5 in background; capture PID immediately
-    taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-      > /local/data/results/id_13_maya.txt 2>&1 &
-    MAYA_PID=$!
+exec >> "$MAYA_LOG_PATH" 2>&1
+echo "[INFO] Maya wrapper started at $(date '+%Y-%m-%d %H:%M:%S')"
 
-    # Small startup delay to avoid cold-start hiccups
-    sleep 1
+command -v /local/bci_code/tools/maya/Dist/Release/Maya >/dev/null || {
+  echo "[ERROR] Maya binary not found"
+  exit 127
+}
+test -x /local/bci_code/tools/maya/Dist/Release/Maya || {
+  echo "[ERROR] Maya not executable"
+  exit 126
+}
 
-    # Portable verification (no 'ps ... cpuset')
-    {
-      echo "[verify] maya pid=$MAYA_PID"
-      ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
-      taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
-      # cpuset/cgroup path (v1 or v2)
-      cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
-      cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
-    } || true
+# Start Maya on CPU 5 in background; capture PID immediately
+taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+  > "$MAYA_TXT_PATH" 2>&1 &
+MAYA_PID=$!
 
-    # Run workload on CPU 6
-    taskset -c 6 /local/tools/matlab/bin/matlab \
-      -nodisplay -nosplash \
-      -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
-      >> /local/data/results/id_13_maya.log 2>&1 || true
+kill -0 "$MAYA_PID" 2>/dev/null || {
+  echo "[ERROR] Maya failed to start"
+  exit 1
+}
 
-    # Idempotent teardown with escalation and reap
-    for sig in TERM KILL; do
-      if kill -0 "$MAYA_PID" 2>/dev/null; then
-        kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
-        timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
-      fi
-      kill -0 "$MAYA_PID" 2>/dev/null || break
-    done
-    wait "$MAYA_PID" 2>/dev/null || true
-  '
+# Small startup delay to avoid cold-start hiccups
+sleep 1
+
+# Portable verification (no 'ps ... cpuset')
+{
+  echo "[verify] maya pid=$MAYA_PID"
+  ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+  taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+  # cpuset/cgroup path (v1 or v2)
+  cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+  cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+} || true
+
+workload_status=0
+# Run workload on CPU 6
+taskset -c 6 /local/tools/matlab/bin/matlab \
+  -nodisplay -nosplash \
+  -r "cd('\''/local/bci_code/id_13'\''); motor_movement('\''/local/data/S5_raw_segmented.mat'\'', '\''/local/tools/fieldtrip/fieldtrip-20240916'\''); exit;" \
+  >> "$MAYA_LOG_PATH" 2>&1 || workload_status=$?
+
+if (( workload_status != 0 )); then
+  echo "[WARN] Workload exited with status ${workload_status}"
+fi
+
+# Idempotent teardown with escalation and reap
+for sig in TERM KILL; do
+  if kill -0 "$MAYA_PID" 2>/dev/null; then
+    kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+    timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+  fi
+  kill -0 "$MAYA_PID" 2>/dev/null || break
+done
+
+set +e
+wait "$MAYA_PID"
+wait_status=$?
+set -e
+
+if (( wait_status != 0 )); then
+  {
+    echo "==================== MAYA FAILURE ===================="
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Exit code: ${wait_status}"
+    if [[ -s "$MAYA_TXT_PATH" ]]; then
+      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
+      cat "$MAYA_TXT_PATH"
+    else
+      echo "(${MAYA_TXT_PATH} missing or empty)"
+    fi
+    echo "===================================================="
+  } >> "$MAYA_LOG_PATH"
+fi
+
+exit "$wait_status"
+EOF
+)
+  {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') Launching Maya wrapper command:"
+    printf 'sudo -E cset shield --exec -- bash -lc %q\n' "$maya_subshell"
+  } >> "$MAYA_LOG_PATH"
+  if ! MAYA_TXT_PATH="$MAYA_TXT_PATH" MAYA_LOG_PATH="$MAYA_LOG_PATH" sudo -E cset shield --exec -- bash -lc "$maya_subshell" 2>>"$MAYA_LOG_PATH"; then
+    maya_failed=true
+    maya_status=$?
+  fi
+
+  if $maya_failed; then
+    echo "Maya profiling failed with status ${maya_status}. See ${MAYA_LOG_PATH} for details."
+    exit "$maya_status"
+  fi
+
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_maya.log
+    > "$MAYA_DONE_PATH"
   log_debug "Maya completed in ${maya_runtime}s"
 fi
 echo
@@ -2078,11 +2143,17 @@ echo
 ################################################################################
 
 if $run_maya; then
-  echo "Converting id_13_maya.txt → id_13_maya.csv"
-  log_debug "Converting Maya output to CSV"
-  awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?"," : "") } print "" }' \
-    /local/data/results/id_13_maya.txt > /local/data/results/id_13_maya.csv
-  log_debug "Maya CSV generated"
+  if (( maya_status != 0 )); then
+    log_debug "Skipping Maya CSV conversion due to failure status ${maya_status}"
+  elif [[ ! -s "$MAYA_TXT_PATH" ]]; then
+    echo "[WARN] Maya output ${MAYA_TXT_PATH} is empty; skipping CSV conversion."
+  else
+    echo "Converting id_13_maya.txt → id_13_maya.csv"
+    log_debug "Converting Maya output to CSV"
+    awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?"," : "") } print "" }' \
+      "$MAYA_TXT_PATH" > "${RESULT_PREFIX}_maya.csv"
+    log_debug "Maya CSV generated"
+  fi
 fi
 echo
 

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -1942,52 +1942,117 @@ if $run_maya; then
   maya_start=$(date +%s)
 
   # Run the LLM script under Maya (Maya on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  set -euo pipefail
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+  MAYA_TXT_PATH="${RESULT_PREFIX}_maya.txt"
+  MAYA_LOG_PATH="${RESULT_PREFIX}_maya.log"
+  MAYA_DONE_PATH="${OUTDIR}/done_llm_maya.log"
+  maya_failed=false
+  maya_status=0
+  : > "$MAYA_LOG_PATH"
+  : > "$MAYA_TXT_PATH"
+  maya_subshell=$(cat <<'EOF'
+set -euo pipefail
+source /local/tools/bci_env/bin/activate
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+. path.sh
+export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-  # Start Maya on CPU 5 in background; capture PID immediately
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_llm_maya.txt 2>&1 &
-  MAYA_PID=$!
+exec >> "$MAYA_LOG_PATH" 2>&1
+echo "[INFO] Maya wrapper started at $(date '+%Y-%m-%d %H:%M:%S')"
 
-  # Small startup delay to avoid cold-start hiccups
-  sleep 1
+command -v /local/bci_code/tools/maya/Dist/Release/Maya >/dev/null || {
+  echo "[ERROR] Maya binary not found"
+  exit 127
+}
+test -x /local/bci_code/tools/maya/Dist/Release/Maya || {
+  echo "[ERROR] Maya not executable"
+  exit 126
+}
 
-  # Portable verification (no 'ps ... cpuset')
+# Start Maya on CPU 5 in background; capture PID immediately
+taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+  > "$MAYA_TXT_PATH" 2>&1 &
+MAYA_PID=$!
+
+kill -0 "$MAYA_PID" 2>/dev/null || {
+  echo "[ERROR] Maya failed to start"
+  exit 1
+}
+
+# Small startup delay to avoid cold-start hiccups
+sleep 1
+
+# Portable verification (no 'ps ... cpuset')
+{
+  echo "[verify] maya pid=$MAYA_PID"
+  ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+  taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+  # cpuset/cgroup path (v1 or v2)
+  cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+  cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+} || true
+
+workload_status=0
+# Run workload on CPU 6
+taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
+  --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+  --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
+  >> "$MAYA_LOG_PATH" 2>&1 || workload_status=$?
+
+if (( workload_status != 0 )); then
+  echo "[WARN] Workload exited with status ${workload_status}"
+fi
+
+# Idempotent teardown with escalation and reap
+for sig in TERM KILL; do
+  if kill -0 "$MAYA_PID" 2>/dev/null; then
+    kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+    timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+  fi
+  kill -0 "$MAYA_PID" 2>/dev/null || break
+done
+
+set +e
+wait "$MAYA_PID"
+wait_status=$?
+set -e
+
+if (( wait_status != 0 )); then
   {
-    echo "[verify] maya pid=$MAYA_PID"
-    ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
-    taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
-    # cpuset/cgroup path (v1 or v2)
-    cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
-    cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
-  } || true
-
-  # Run workload on CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/llm_model_run.py \
-    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    --nbRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/lm_output/nbest_results.pkl \
-    >> /local/data/results/id_20_3gram_llm_maya.log 2>&1 || true
-
-  # Idempotent teardown with escalation and reap
-  for sig in TERM KILL; do
-    if kill -0 "$MAYA_PID" 2>/dev/null; then
-      kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
-      timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+    echo "==================== MAYA FAILURE ===================="
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Exit code: ${wait_status}"
+    if [[ -s "$MAYA_TXT_PATH" ]]; then
+      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
+      cat "$MAYA_TXT_PATH"
+    else
+      echo "(${MAYA_TXT_PATH} missing or empty)"
     fi
-    kill -0 "$MAYA_PID" 2>/dev/null || break
-  done
-  wait "$MAYA_PID" 2>/dev/null || true
-  '
+    echo "===================================================="
+  } >> "$MAYA_LOG_PATH"
+fi
+
+exit "$wait_status"
+EOF
+)
+  {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') Launching Maya wrapper command:"
+    printf 'sudo -E cset shield --exec -- bash -lc %q\n' "$maya_subshell"
+  } >> "$MAYA_LOG_PATH"
+  if ! MAYA_TXT_PATH="$MAYA_TXT_PATH" MAYA_LOG_PATH="$MAYA_LOG_PATH" sudo -E cset shield --exec -- bash -lc "$maya_subshell" 2>>"$MAYA_LOG_PATH"; then
+    maya_failed=true
+    maya_status=$?
+  fi
+
+  if $maya_failed; then
+    echo "Maya profiling failed with status ${maya_status}. See ${MAYA_LOG_PATH} for details."
+    exit "$maya_status"
+  fi
+
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_llm_maya.log
+    > "$MAYA_DONE_PATH"
   log_debug "Maya completed in ${maya_runtime}s"
 fi
 echo
@@ -2104,12 +2169,18 @@ echo
 ################################################################################
 
 if $run_maya; then
-  echo "Converting id_20_3gram_llm_maya.txt → id_20_3gram_llm_maya.csv"
-  log_debug "Converting Maya output to CSV"
-  awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
-    /local/data/results/id_20_3gram_llm_maya.txt \
-    > /local/data/results/id_20_3gram_llm_maya.csv
-  log_debug "Maya CSV generated"
+  if (( maya_status != 0 )); then
+    log_debug "Skipping Maya CSV conversion due to failure status ${maya_status}"
+  elif [[ ! -s "$MAYA_TXT_PATH" ]]; then
+    echo "[WARN] Maya output ${MAYA_TXT_PATH} is empty; skipping CSV conversion."
+  else
+    echo "Converting id_20_3gram_llm_maya.txt → id_20_3gram_llm_maya.csv"
+    log_debug "Converting Maya output to CSV"
+    awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
+      "$MAYA_TXT_PATH" \
+      > "${RESULT_PREFIX}_maya.csv"
+    log_debug "Maya CSV generated"
+  fi
 fi
 echo
 

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -1942,52 +1942,117 @@ if $run_maya; then
   maya_start=$(date +%s)
 
   # Run the LM script under Maya (Maya on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  set -euo pipefail
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+  MAYA_TXT_PATH="${RESULT_PREFIX}_maya.txt"
+  MAYA_LOG_PATH="${RESULT_PREFIX}_maya.log"
+  MAYA_DONE_PATH="${OUTDIR}/done_lm_maya.log"
+  maya_failed=false
+  maya_status=0
+  : > "$MAYA_LOG_PATH"
+  : > "$MAYA_TXT_PATH"
+  maya_subshell=$(cat <<'EOF'
+set -euo pipefail
+source /local/tools/bci_env/bin/activate
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+. path.sh
+export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-  # Start Maya on CPU 5 in background; capture PID immediately
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_lm_maya.txt 2>&1 &
-  MAYA_PID=$!
+exec >> "$MAYA_LOG_PATH" 2>&1
+echo "[INFO] Maya wrapper started at $(date '+%Y-%m-%d %H:%M:%S')"
 
-  # Small startup delay to avoid cold-start hiccups
-  sleep 1
+command -v /local/bci_code/tools/maya/Dist/Release/Maya >/dev/null || {
+  echo "[ERROR] Maya binary not found"
+  exit 127
+}
+test -x /local/bci_code/tools/maya/Dist/Release/Maya || {
+  echo "[ERROR] Maya not executable"
+  exit 126
+}
 
-  # Portable verification (no 'ps ... cpuset')
+# Start Maya on CPU 5 in background; capture PID immediately
+taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+  > "$MAYA_TXT_PATH" 2>&1 &
+MAYA_PID=$!
+
+kill -0 "$MAYA_PID" 2>/dev/null || {
+  echo "[ERROR] Maya failed to start"
+  exit 1
+}
+
+# Small startup delay to avoid cold-start hiccups
+sleep 1
+
+# Portable verification (no 'ps ... cpuset')
+{
+  echo "[verify] maya pid=$MAYA_PID"
+  ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+  taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+  # cpuset/cgroup path (v1 or v2)
+  cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+  cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+} || true
+
+workload_status=0
+# Run workload on CPU 6
+taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
+  --lmDir=/local/data/languageModel/ \
+  --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
+  >> "$MAYA_LOG_PATH" 2>&1 || workload_status=$?
+
+if (( workload_status != 0 )); then
+  echo "[WARN] Workload exited with status ${workload_status}"
+fi
+
+# Idempotent teardown with escalation and reap
+for sig in TERM KILL; do
+  if kill -0 "$MAYA_PID" 2>/dev/null; then
+    kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+    timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+  fi
+  kill -0 "$MAYA_PID" 2>/dev/null || break
+done
+
+set +e
+wait "$MAYA_PID"
+wait_status=$?
+set -e
+
+if (( wait_status != 0 )); then
   {
-    echo "[verify] maya pid=$MAYA_PID"
-    ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
-    taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
-    # cpuset/cgroup path (v1 or v2)
-    cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
-    cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
-  } || true
-
-  # Run workload on CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/wfst_model_run.py \
-    --lmDir=/local/data/languageModel/ \
-    --rnnRes=/proj/nejsustain-PG0/data/bci/id-20/outputs/3gram/rnn_output/rnn_results.pkl \
-    >> /local/data/results/id_20_3gram_lm_maya.log 2>&1 || true
-
-  # Idempotent teardown with escalation and reap
-  for sig in TERM KILL; do
-    if kill -0 "$MAYA_PID" 2>/dev/null; then
-      kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
-      timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+    echo "==================== MAYA FAILURE ===================="
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Exit code: ${wait_status}"
+    if [[ -s "$MAYA_TXT_PATH" ]]; then
+      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
+      cat "$MAYA_TXT_PATH"
+    else
+      echo "(${MAYA_TXT_PATH} missing or empty)"
     fi
-    kill -0 "$MAYA_PID" 2>/dev/null || break
-  done
-  wait "$MAYA_PID" 2>/dev/null || true
-  '
+    echo "===================================================="
+  } >> "$MAYA_LOG_PATH"
+fi
+
+exit "$wait_status"
+EOF
+)
+  {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') Launching Maya wrapper command:"
+    printf 'sudo -E cset shield --exec -- bash -lc %q\n' "$maya_subshell"
+  } >> "$MAYA_LOG_PATH"
+  if ! MAYA_TXT_PATH="$MAYA_TXT_PATH" MAYA_LOG_PATH="$MAYA_LOG_PATH" sudo -E cset shield --exec -- bash -lc "$maya_subshell" 2>>"$MAYA_LOG_PATH"; then
+    maya_failed=true
+    maya_status=$?
+  fi
+
+  if $maya_failed; then
+    echo "Maya profiling failed with status ${maya_status}. See ${MAYA_LOG_PATH} for details."
+    exit "$maya_status"
+  fi
+
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_lm_maya.log
+    > "$MAYA_DONE_PATH"
   log_debug "Maya completed in ${maya_runtime}s"
 fi
 echo
@@ -2104,12 +2169,18 @@ echo
 ################################################################################
 
 if $run_maya; then
-  echo "Converting id_20_3gram_lm_maya.txt → id_20_3gram_lm_maya.csv"
-  log_debug "Converting Maya output to CSV"
-  awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
-    /local/data/results/id_20_3gram_lm_maya.txt \
-    > /local/data/results/id_20_3gram_lm_maya.csv
-  log_debug "Maya CSV generated"
+  if (( maya_status != 0 )); then
+    log_debug "Skipping Maya CSV conversion due to failure status ${maya_status}"
+  elif [[ ! -s "$MAYA_TXT_PATH" ]]; then
+    echo "[WARN] Maya output ${MAYA_TXT_PATH} is empty; skipping CSV conversion."
+  else
+    echo "Converting id_20_3gram_lm_maya.txt → id_20_3gram_lm_maya.csv"
+    log_debug "Converting Maya output to CSV"
+    awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
+      "$MAYA_TXT_PATH" \
+      > "${RESULT_PREFIX}_maya.csv"
+    log_debug "Maya CSV generated"
+  fi
 fi
 echo
 

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -1942,52 +1942,117 @@ if $run_maya; then
   maya_start=$(date +%s)
 
   # Run the RNN script under Maya (Maya on CPU 5, workload on CPU 6)
-  sudo -E cset shield --exec -- bash -lc '
-  set -euo pipefail
-  source /local/tools/bci_env/bin/activate
-  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-  . path.sh
-  export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
+  MAYA_TXT_PATH="${RESULT_PREFIX}_maya.txt"
+  MAYA_LOG_PATH="${RESULT_PREFIX}_maya.log"
+  MAYA_DONE_PATH="${OUTDIR}/done_rnn_maya.log"
+  maya_failed=false
+  maya_status=0
+  : > "$MAYA_LOG_PATH"
+  : > "$MAYA_TXT_PATH"
+  maya_subshell=$(cat <<'EOF'
+set -euo pipefail
+source /local/tools/bci_env/bin/activate
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+. path.sh
+export PYTHONPATH="$(pwd)/bci_code/id_20/code/neural_seq_decoder/src:${PYTHONPATH:-}"
 
-  # Start Maya on CPU 5 in background; capture PID immediately
-  taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
-    > /local/data/results/id_20_3gram_rnn_maya.txt 2>&1 &
-  MAYA_PID=$!
+exec >> "$MAYA_LOG_PATH" 2>&1
+echo "[INFO] Maya wrapper started at $(date '+%Y-%m-%d %H:%M:%S')"
 
-  # Small startup delay to avoid cold-start hiccups
-  sleep 1
+command -v /local/bci_code/tools/maya/Dist/Release/Maya >/dev/null || {
+  echo "[ERROR] Maya binary not found"
+  exit 127
+}
+test -x /local/bci_code/tools/maya/Dist/Release/Maya || {
+  echo "[ERROR] Maya not executable"
+  exit 126
+}
 
-  # Portable verification (no 'ps ... cpuset')
+# Start Maya on CPU 5 in background; capture PID immediately
+taskset -c 5 /local/bci_code/tools/maya/Dist/Release/Maya --mode Baseline \
+  > "$MAYA_TXT_PATH" 2>&1 &
+MAYA_PID=$!
+
+kill -0 "$MAYA_PID" 2>/dev/null || {
+  echo "[ERROR] Maya failed to start"
+  exit 1
+}
+
+# Small startup delay to avoid cold-start hiccups
+sleep 1
+
+# Portable verification (no 'ps ... cpuset')
+{
+  echo "[verify] maya pid=$MAYA_PID"
+  ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
+  taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
+  # cpuset/cgroup path (v1 or v2)
+  cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
+  cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
+} || true
+
+workload_status=0
+# Run workload on CPU 6
+taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
+  --datasetPath=/local/data/ptDecoder_ctc \
+  --modelPath=/local/data/speechBaseline4/ \
+  >> "$MAYA_LOG_PATH" 2>&1 || workload_status=$?
+
+if (( workload_status != 0 )); then
+  echo "[WARN] Workload exited with status ${workload_status}"
+fi
+
+# Idempotent teardown with escalation and reap
+for sig in TERM KILL; do
+  if kill -0 "$MAYA_PID" 2>/dev/null; then
+    kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
+    timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+  fi
+  kill -0 "$MAYA_PID" 2>/dev/null || break
+done
+
+set +e
+wait "$MAYA_PID"
+wait_status=$?
+set -e
+
+if (( wait_status != 0 )); then
   {
-    echo "[verify] maya pid=$MAYA_PID"
-    ps -o pid,psr,comm -p "$MAYA_PID" || true                # processor column is widely supported
-    taskset -cp "$MAYA_PID" || true                          # shows allowed CPUs
-    # cpuset/cgroup path (v1 or v2)
-    cat "/proc/$MAYA_PID/cpuset" 2>/dev/null || \
-    cat "/proc/$MAYA_PID/cgroup" 2>/dev/null || true
-  } || true
-
-  # Run workload on CPU 6
-  taskset -c 6 python3 bci_code/id_20/code/neural_seq_decoder/scripts/rnn_run.py \
-    --datasetPath=/local/data/ptDecoder_ctc \
-    --modelPath=/local/data/speechBaseline4/ \
-    >> /local/data/results/id_20_3gram_rnn_maya.log 2>&1 || true
-
-  # Idempotent teardown with escalation and reap
-  for sig in TERM KILL; do
-    if kill -0 "$MAYA_PID" 2>/dev/null; then
-      kill -s "$sig" "$MAYA_PID" 2>/dev/null || true
-      timeout 5s bash -lc "while kill -0 $MAYA_PID 2>/dev/null; do sleep 0.2; done" || true
+    echo "==================== MAYA FAILURE ===================="
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Exit code: ${wait_status}"
+    if [[ -s "$MAYA_TXT_PATH" ]]; then
+      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
+      cat "$MAYA_TXT_PATH"
+    else
+      echo "(${MAYA_TXT_PATH} missing or empty)"
     fi
-    kill -0 "$MAYA_PID" 2>/dev/null || break
-  done
-  wait "$MAYA_PID" 2>/dev/null || true
-  '
+    echo "===================================================="
+  } >> "$MAYA_LOG_PATH"
+fi
+
+exit "$wait_status"
+EOF
+)
+  {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') Launching Maya wrapper command:"
+    printf 'sudo -E cset shield --exec -- bash -lc %q\n' "$maya_subshell"
+  } >> "$MAYA_LOG_PATH"
+  if ! MAYA_TXT_PATH="$MAYA_TXT_PATH" MAYA_LOG_PATH="$MAYA_LOG_PATH" sudo -E cset shield --exec -- bash -lc "$maya_subshell" 2>>"$MAYA_LOG_PATH"; then
+    maya_failed=true
+    maya_status=$?
+  fi
+
+  if $maya_failed; then
+    echo "Maya profiling failed with status ${maya_status}. See ${MAYA_LOG_PATH} for details."
+    exit "$maya_status"
+  fi
+
   maya_end=$(date +%s)
   echo "Maya profiling finished at: $(timestamp)"
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
-    > /local/data/results/done_rnn_maya.log
+    > "$MAYA_DONE_PATH"
   log_debug "Maya completed in ${maya_runtime}s"
 fi
 echo
@@ -2106,12 +2171,18 @@ echo
 ################################################################################
 
 if $run_maya; then
-  echo "Converting id_20_3gram_rnn_maya.txt → id_20_3gram_rnn_maya.csv"
-  log_debug "Converting Maya output to CSV"
-  awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
-    /local/data/results/id_20_3gram_rnn_maya.txt \
-    > /local/data/results/id_20_3gram_rnn_maya.csv
-  log_debug "Maya CSV generated"
+  if (( maya_status != 0 )); then
+    log_debug "Skipping Maya CSV conversion due to failure status ${maya_status}"
+  elif [[ ! -s "$MAYA_TXT_PATH" ]]; then
+    echo "[WARN] Maya output ${MAYA_TXT_PATH} is empty; skipping CSV conversion."
+  else
+    echo "Converting id_20_3gram_rnn_maya.txt → id_20_3gram_rnn_maya.csv"
+    log_debug "Converting Maya output to CSV"
+    awk '{ for(i=1;i<=NF;i++){ printf "%s%s", $i, (i<NF?",":"") } print "" }' \
+      "$MAYA_TXT_PATH" \
+      > "${RESULT_PREFIX}_maya.csv"
+    log_debug "Maya CSV generated"
+  fi
 fi
 echo
 


### PR DESCRIPTION
## Summary
- precreate Maya output artifacts, log the wrapper command, and validate the profiler binary before launching in every Maya-enabled run script
- capture workload exit statuses, emit detailed failure banners with timestamps and raw text, and propagate Maya’s exit code back to the parent shells across the suite
- skip Maya CSV conversion when profiling fails or the raw output file is empty so downstream stages never process bogus data

## Testing
- bash -n scripts/run_1.sh
- bash -n scripts/run_3.sh
- bash -n scripts/run_13.sh
- bash -n scripts/run_20_3gram_llm.sh
- bash -n scripts/run_20_3gram_lm.sh
- bash -n scripts/run_20_3gram_rnn.sh

------
https://chatgpt.com/codex/tasks/task_e_68e56856967c832c850d041f92577304