### PR TITLE
Avoid duplicating Maya output in failure logs

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1969,10 +1969,9 @@ if (( wait_status != 0 )); then
     echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
     echo "Exit code: ${wait_status}"
     if [[ -s "$MAYA_TXT_PATH" ]]; then
-      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
-      cat "$MAYA_TXT_PATH"
+      echo "[INFO] Maya output preserved at ${MAYA_TXT_PATH}"
     else
-      echo "(${MAYA_TXT_PATH} missing or empty)"
+      echo "[WARN] ${MAYA_TXT_PATH} missing or empty"
     fi
     echo "===================================================="
   } >> "$MAYA_LOG_PATH"

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1999,10 +1999,9 @@ if (( wait_status != 0 )); then
     echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
     echo "Exit code: ${wait_status}"
     if [[ -s "$MAYA_TXT_PATH" ]]; then
-      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
-      cat "$MAYA_TXT_PATH"
+      echo "[INFO] Maya output preserved at ${MAYA_TXT_PATH}"
     else
-      echo "(${MAYA_TXT_PATH} missing or empty)"
+      echo "[WARN] ${MAYA_TXT_PATH} missing or empty"
     fi
     echo "===================================================="
   } >> "$MAYA_LOG_PATH"

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -2022,10 +2022,9 @@ if (( wait_status != 0 )); then
     echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
     echo "Exit code: ${wait_status}"
     if [[ -s "$MAYA_TXT_PATH" ]]; then
-      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
-      cat "$MAYA_TXT_PATH"
+      echo "[INFO] Maya output preserved at ${MAYA_TXT_PATH}"
     else
-      echo "(${MAYA_TXT_PATH} missing or empty)"
+      echo "[WARN] ${MAYA_TXT_PATH} missing or empty"
     fi
     echo "===================================================="
   } >> "$MAYA_LOG_PATH"

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -2022,10 +2022,9 @@ if (( wait_status != 0 )); then
     echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
     echo "Exit code: ${wait_status}"
     if [[ -s "$MAYA_TXT_PATH" ]]; then
-      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
-      cat "$MAYA_TXT_PATH"
+      echo "[INFO] Maya output preserved at ${MAYA_TXT_PATH}"
     else
-      echo "(${MAYA_TXT_PATH} missing or empty)"
+      echo "[WARN] ${MAYA_TXT_PATH} missing or empty"
     fi
     echo "===================================================="
   } >> "$MAYA_LOG_PATH"

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -2022,10 +2022,9 @@ if (( wait_status != 0 )); then
     echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
     echo "Exit code: ${wait_status}"
     if [[ -s "$MAYA_TXT_PATH" ]]; then
-      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
-      cat "$MAYA_TXT_PATH"
+      echo "[INFO] Maya output preserved at ${MAYA_TXT_PATH}"
     else
-      echo "(${MAYA_TXT_PATH} missing or empty)"
+      echo "[WARN] ${MAYA_TXT_PATH} missing or empty"
     fi
     echo "===================================================="
   } >> "$MAYA_LOG_PATH"

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -1981,10 +1981,9 @@ if (( wait_status != 0 )); then
     echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
     echo "Exit code: ${wait_status}"
     if [[ -s "$MAYA_TXT_PATH" ]]; then
-      echo "-------------------- ${MAYA_TXT_PATH##*/} -----------------"
-      cat "$MAYA_TXT_PATH"
+      echo "[INFO] Maya output preserved at ${MAYA_TXT_PATH}"
     else
-      echo "(${MAYA_TXT_PATH} missing or empty)"
+      echo "[WARN] ${MAYA_TXT_PATH} missing or empty"
     fi
     echo "===================================================="
   } >> "$MAYA_LOG_PATH"


### PR DESCRIPTION
## Summary
- stop dumping the Maya text report into the failure log in each run script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e581fe077c832c950c31a232b9b85b