### PR TITLE
Handle intentional Maya SIGTERM after successful workloads

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -1963,6 +1963,13 @@ wait "$MAYA_PID"
 wait_status=$?
 set -e
 
+if (( wait_status == 143 || wait_status == 15 )); then
+  if (( workload_status == 0 )) && grep -q "Workload finished successfully" "$MAYA_LOG_PATH"; then
+    echo "[INFO] Maya received SIGTERM after successful workload completion; treating as expected shutdown."
+    wait_status=0
+  fi
+fi
+
 if (( wait_status != 0 )); then
   {
     echo "==================== MAYA FAILURE ===================="

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -1993,6 +1993,13 @@ wait "$MAYA_PID"
 wait_status=$?
 set -e
 
+if (( wait_status == 143 || wait_status == 15 )); then
+  if (( workload_status == 0 )) && grep -q "Workload finished successfully" "$MAYA_LOG_PATH"; then
+    echo "[INFO] Maya received SIGTERM after successful workload completion; treating as expected shutdown."
+    wait_status=0
+  fi
+fi
+
 if (( wait_status != 0 )); then
   {
     echo "==================== MAYA FAILURE ===================="

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -2016,6 +2016,13 @@ wait "$MAYA_PID"
 wait_status=$?
 set -e
 
+if (( wait_status == 143 || wait_status == 15 )); then
+  if (( workload_status == 0 )) && grep -q "Workload finished successfully" "$MAYA_LOG_PATH"; then
+    echo "[INFO] Maya received SIGTERM after successful workload completion; treating as expected shutdown."
+    wait_status=0
+  fi
+fi
+
 if (( wait_status != 0 )); then
   {
     echo "==================== MAYA FAILURE ===================="

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -2016,6 +2016,13 @@ wait "$MAYA_PID"
 wait_status=$?
 set -e
 
+if (( wait_status == 143 || wait_status == 15 )); then
+  if (( workload_status == 0 )) && grep -q "Workload finished successfully" "$MAYA_LOG_PATH"; then
+    echo "[INFO] Maya received SIGTERM after successful workload completion; treating as expected shutdown."
+    wait_status=0
+  fi
+fi
+
 if (( wait_status != 0 )); then
   {
     echo "==================== MAYA FAILURE ===================="

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -2016,6 +2016,13 @@ wait "$MAYA_PID"
 wait_status=$?
 set -e
 
+if (( wait_status == 143 || wait_status == 15 )); then
+  if (( workload_status == 0 )) && grep -q "Workload finished successfully" "$MAYA_LOG_PATH"; then
+    echo "[INFO] Maya received SIGTERM after successful workload completion; treating as expected shutdown."
+    wait_status=0
+  fi
+fi
+
 if (( wait_status != 0 )); then
   {
     echo "==================== MAYA FAILURE ===================="

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -1975,6 +1975,13 @@ wait "$MAYA_PID"
 wait_status=$?
 set -e
 
+if (( wait_status == 143 || wait_status == 15 )); then
+  if (( workload_status == 0 )) && grep -q "Workload finished successfully" "$MAYA_LOG_PATH"; then
+    echo "[INFO] Maya received SIGTERM after successful workload completion; treating as expected shutdown."
+    wait_status=0
+  fi
+fi
+
 if (( wait_status != 0 )); then
   {
     echo "==================== MAYA FAILURE ===================="


### PR DESCRIPTION
## Summary
- treat Maya SIGTERM after a successful workload as an expected shutdown in the run_1 Maya wrapper and log the intentional termination
- mirror the adjusted handling in run_3, run_13, and the run_20_3gram wrappers so Maya failures are only flagged for genuine non-zero exits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e594811678832ca47724c0c0c4760a