### PR TITLE
Format runtime logs with adaptive units

### DIFF
--- a/scripts/run_1.sh
+++ b/scripts/run_1.sh
@@ -583,10 +583,28 @@ pcm_power_end=0
 pcm_pcie_start=0
 pcm_pcie_end=0
 
-# Format seconds as "Xd Yh Zm"
+# Format seconds with adaptive units
 secs_to_dhm() {
-  local total=$1
-  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+  local total=${1:-0}
+  if (( total < 0 )); then
+    total=$((-total))
+  fi
+  if (( total < 60 )); then
+    printf '%ds' "${total}"
+  elif (( total < 3600 )); then
+    local minutes=$((total / 60))
+    local seconds=$((total % 60))
+    printf '%dm %ds' "${minutes}" "${seconds}"
+  elif (( total < 86400 )); then
+    local hours=$((total / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dh %dm' "${hours}" "${minutes}"
+  else
+    local days=$((total / 86400))
+    local hours=$(((total % 86400) / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dd %dh %dm' "${days}" "${hours}" "${minutes}"
+  fi
 }
 
 prefix_lines() {
@@ -902,7 +920,7 @@ if $run_pcm_pcie; then
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_pcm_pcie.log
-  log_debug "pcm-pcie completed in ${pcm_pcie_runtime}s"
+  log_debug "pcm-pcie completed in $(secs_to_dhm "$pcm_pcie_runtime")"
 fi
 
 if $run_pcm; then
@@ -926,7 +944,7 @@ if $run_pcm; then
   pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
-  log_debug "pcm completed in ${pcm_runtime}s"
+  log_debug "pcm completed in $(secs_to_dhm "$pcm_runtime")"
 fi
 
 if $run_pcm_memory; then
@@ -950,7 +968,7 @@ if $run_pcm_memory; then
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
-  log_debug "pcm-memory completed in ${pcm_mem_runtime}s"
+  log_debug "pcm-memory completed in $(secs_to_dhm "$pcm_mem_runtime")"
 fi
 
 if $run_pcm_power; then
@@ -1863,7 +1881,7 @@ if __name__ == "__main__":
     main()
 PY
 
-  log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  log_debug "pcm-power completed in $(secs_to_dhm "$pcm_power_runtime")"
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -2006,7 +2024,7 @@ EOF
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > "$MAYA_DONE_PATH"
-  log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya completed in $(secs_to_dhm "$maya_runtime")"
 fi
 echo
 
@@ -2036,7 +2054,7 @@ if $run_toplev_basic; then
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_toplev_basic.log
-  log_debug "Toplev basic completed in ${toplev_basic_runtime}s"
+  log_debug "Toplev basic completed in $(secs_to_dhm "$toplev_basic_runtime")"
 fi
 echo
 
@@ -2065,7 +2083,7 @@ if $run_toplev_execution; then
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
-  log_debug "Toplev execution completed in ${toplev_execution_runtime}s"
+  log_debug "Toplev execution completed in $(secs_to_dhm "$toplev_execution_runtime")"
 fi
 echo
 
@@ -2094,7 +2112,7 @@ if $run_toplev_full; then
   toplev_full_runtime=$((toplev_full_end - toplev_full_start))
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_toplev_full.log
-  log_debug "Toplev full completed in ${toplev_full_runtime}s"
+  log_debug "Toplev full completed in $(secs_to_dhm "$toplev_full_runtime")"
 fi
 echo
 

--- a/scripts/run_13.sh
+++ b/scripts/run_13.sh
@@ -583,10 +583,28 @@ pcm_power_end=0
 pcm_pcie_start=0
 pcm_pcie_end=0
 
-# Format seconds as "Xd Yh Zm"
+# Format seconds with adaptive units
 secs_to_dhm() {
-  local total=$1
-  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+  local total=${1:-0}
+  if (( total < 0 )); then
+    total=$((-total))
+  fi
+  if (( total < 60 )); then
+    printf '%ds' "${total}"
+  elif (( total < 3600 )); then
+    local minutes=$((total / 60))
+    local seconds=$((total % 60))
+    printf '%dm %ds' "${minutes}" "${seconds}"
+  elif (( total < 86400 )); then
+    local hours=$((total / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dh %dm' "${hours}" "${minutes}"
+  else
+    local days=$((total / 86400))
+    local hours=$(((total % 86400) / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dd %dh %dm' "${days}" "${hours}" "${minutes}"
+  fi
 }
 
 prefix_lines() {
@@ -908,7 +926,7 @@ if $run_pcm_pcie; then
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_pcm_pcie.log
-  log_debug "pcm-pcie completed in ${pcm_pcie_runtime}s"
+  log_debug "pcm-pcie completed in $(secs_to_dhm "$pcm_pcie_runtime")"
 fi
 
 if $run_pcm; then
@@ -938,7 +956,7 @@ if $run_pcm; then
   pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
-  log_debug "pcm completed in ${pcm_runtime}s"
+  log_debug "pcm completed in $(secs_to_dhm "$pcm_runtime")"
 fi
 
 if $run_pcm_memory; then
@@ -968,7 +986,7 @@ if $run_pcm_memory; then
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
-  log_debug "pcm-memory completed in ${pcm_mem_runtime}s"
+  log_debug "pcm-memory completed in $(secs_to_dhm "$pcm_mem_runtime")"
 fi
 
 if $run_pcm_power; then
@@ -1887,7 +1905,7 @@ if __name__ == "__main__":
     main()
 PY
 
-  log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  log_debug "pcm-power completed in $(secs_to_dhm "$pcm_power_runtime")"
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -2036,7 +2054,7 @@ EOF
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > "$MAYA_DONE_PATH"
-  log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya completed in $(secs_to_dhm "$maya_runtime")"
 fi
 echo
 
@@ -2072,7 +2090,7 @@ if $run_toplev_basic; then
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_toplev_basic.log
-  log_debug "Toplev basic completed in ${toplev_basic_runtime}s"
+  log_debug "Toplev basic completed in $(secs_to_dhm "$toplev_basic_runtime")"
 fi
 echo
 
@@ -2106,7 +2124,7 @@ if $run_toplev_execution; then
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
-  log_debug "Toplev execution completed in ${toplev_execution_runtime}s"
+  log_debug "Toplev execution completed in $(secs_to_dhm "$toplev_execution_runtime")"
 fi
 echo
 
@@ -2140,7 +2158,7 @@ if $run_toplev_full; then
   toplev_full_runtime=$((toplev_full_end - toplev_full_start))
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_toplev_full.log
-  log_debug "Toplev full completed in ${toplev_full_runtime}s"
+  log_debug "Toplev full completed in $(secs_to_dhm "$toplev_full_runtime")"
 fi
 echo
 

--- a/scripts/run_20_3gram_llm.sh
+++ b/scripts/run_20_3gram_llm.sh
@@ -583,10 +583,28 @@ pcm_power_end=0
 pcm_pcie_start=0
 pcm_pcie_end=0
 
-# Format seconds as "Xd Yh Zm"
+# Format seconds with adaptive units
 secs_to_dhm() {
-  local total=$1
-  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+  local total=${1:-0}
+  if (( total < 0 )); then
+    total=$((-total))
+  fi
+  if (( total < 60 )); then
+    printf '%ds' "${total}"
+  elif (( total < 3600 )); then
+    local minutes=$((total / 60))
+    local seconds=$((total % 60))
+    printf '%dm %ds' "${minutes}" "${seconds}"
+  elif (( total < 86400 )); then
+    local hours=$((total / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dh %dm' "${hours}" "${minutes}"
+  else
+    local days=$((total / 86400))
+    local hours=$(((total % 86400) / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dd %dh %dm' "${days}" "${hours}" "${minutes}"
+  fi
 }
 
 prefix_lines() {
@@ -913,7 +931,7 @@ if $run_pcm_pcie; then
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_llm_pcm_pcie.log
-  log_debug "pcm-pcie completed in ${pcm_pcie_runtime}s"
+  log_debug "pcm-pcie completed in $(secs_to_dhm "$pcm_pcie_runtime")"
 fi
 
 if $run_pcm; then
@@ -948,7 +966,7 @@ if $run_pcm; then
   pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_llm_pcm.log
-  log_debug "pcm completed in ${pcm_runtime}s"
+  log_debug "pcm completed in $(secs_to_dhm "$pcm_runtime")"
 fi
 
 if $run_pcm_memory; then
@@ -983,7 +1001,7 @@ if $run_pcm_memory; then
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_llm_pcm_memory.log
-  log_debug "pcm-memory completed in ${pcm_mem_runtime}s"
+  log_debug "pcm-memory completed in $(secs_to_dhm "$pcm_mem_runtime")"
 fi
 
 if $run_pcm_power; then
@@ -1907,7 +1925,7 @@ if __name__ == "__main__":
     main()
 PY
 
-  log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  log_debug "pcm-power completed in $(secs_to_dhm "$pcm_power_runtime")"
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -2059,7 +2077,7 @@ EOF
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > "$MAYA_DONE_PATH"
-  log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya completed in $(secs_to_dhm "$maya_runtime")"
 fi
 echo
 
@@ -2096,7 +2114,7 @@ if $run_toplev_basic; then
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_llm_toplev_basic.log
-  log_debug "Toplev basic completed in ${toplev_basic_runtime}s"
+  log_debug "Toplev basic completed in $(secs_to_dhm "$toplev_basic_runtime")"
 fi
 echo
 
@@ -2131,7 +2149,7 @@ if $run_toplev_execution; then
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_llm_toplev_execution.log
-  log_debug "Toplev execution completed in ${toplev_execution_runtime}s"
+  log_debug "Toplev execution completed in $(secs_to_dhm "$toplev_execution_runtime")"
 fi
 echo
 
@@ -2166,7 +2184,7 @@ if $run_toplev_full; then
   toplev_full_runtime=$((toplev_full_end - toplev_full_start))
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_llm_toplev_full.log
-  log_debug "Toplev full completed in ${toplev_full_runtime}s"
+  log_debug "Toplev full completed in $(secs_to_dhm "$toplev_full_runtime")"
 fi
 echo
 

--- a/scripts/run_20_3gram_lm.sh
+++ b/scripts/run_20_3gram_lm.sh
@@ -583,10 +583,28 @@ pcm_power_end=0
 pcm_pcie_start=0
 pcm_pcie_end=0
 
-# Format seconds as "Xd Yh Zm"
+# Format seconds with adaptive units
 secs_to_dhm() {
-  local total=$1
-  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+  local total=${1:-0}
+  if (( total < 0 )); then
+    total=$((-total))
+  fi
+  if (( total < 60 )); then
+    printf '%ds' "${total}"
+  elif (( total < 3600 )); then
+    local minutes=$((total / 60))
+    local seconds=$((total % 60))
+    printf '%dm %ds' "${minutes}" "${seconds}"
+  elif (( total < 86400 )); then
+    local hours=$((total / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dh %dm' "${hours}" "${minutes}"
+  else
+    local days=$((total / 86400))
+    local hours=$(((total % 86400) / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dd %dh %dm' "${days}" "${hours}" "${minutes}"
+  fi
 }
 
 prefix_lines() {
@@ -913,7 +931,7 @@ if $run_pcm_pcie; then
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_lm_pcm_pcie.log
-  log_debug "pcm-pcie completed in ${pcm_pcie_runtime}s"
+  log_debug "pcm-pcie completed in $(secs_to_dhm "$pcm_pcie_runtime")"
 fi
 
 if $run_pcm; then
@@ -948,7 +966,7 @@ if $run_pcm; then
   pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_lm_pcm.log
-  log_debug "pcm completed in ${pcm_runtime}s"
+  log_debug "pcm completed in $(secs_to_dhm "$pcm_runtime")"
 fi
 
 if $run_pcm_memory; then
@@ -983,7 +1001,7 @@ if $run_pcm_memory; then
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_lm_pcm_memory.log
-  log_debug "pcm-memory completed in ${pcm_mem_runtime}s"
+  log_debug "pcm-memory completed in $(secs_to_dhm "$pcm_mem_runtime")"
 fi
 
 if $run_pcm_power; then
@@ -1907,7 +1925,7 @@ if __name__ == "__main__":
     main()
 PY
 
-  log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  log_debug "pcm-power completed in $(secs_to_dhm "$pcm_power_runtime")"
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -2059,7 +2077,7 @@ EOF
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > "$MAYA_DONE_PATH"
-  log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya completed in $(secs_to_dhm "$maya_runtime")"
 fi
 echo
 
@@ -2097,7 +2115,7 @@ if $run_toplev_basic; then
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_lm_toplev_basic.log
-  log_debug "Toplev basic completed in ${toplev_basic_runtime}s"
+  log_debug "Toplev basic completed in $(secs_to_dhm "$toplev_basic_runtime")"
 fi
 echo
 
@@ -2132,7 +2150,7 @@ if $run_toplev_execution; then
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_lm_toplev_execution.log
-  log_debug "Toplev execution completed in ${toplev_execution_runtime}s"
+  log_debug "Toplev execution completed in $(secs_to_dhm "$toplev_execution_runtime")"
 fi
 echo
 
@@ -2167,7 +2185,7 @@ if $run_toplev_full; then
   toplev_full_runtime=$((toplev_full_end - toplev_full_start))
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_lm_toplev_full.log
-  log_debug "Toplev full completed in ${toplev_full_runtime}s"
+  log_debug "Toplev full completed in $(secs_to_dhm "$toplev_full_runtime")"
 fi
 echo
 ################################################################################

--- a/scripts/run_20_3gram_rnn.sh
+++ b/scripts/run_20_3gram_rnn.sh
@@ -583,10 +583,28 @@ pcm_power_end=0
 pcm_pcie_start=0
 pcm_pcie_end=0
 
-# Format seconds as "Xd Yh Zm"
+# Format seconds with adaptive units
 secs_to_dhm() {
-  local total=$1
-  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+  local total=${1:-0}
+  if (( total < 0 )); then
+    total=$((-total))
+  fi
+  if (( total < 60 )); then
+    printf '%ds' "${total}"
+  elif (( total < 3600 )); then
+    local minutes=$((total / 60))
+    local seconds=$((total % 60))
+    printf '%dm %ds' "${minutes}" "${seconds}"
+  elif (( total < 86400 )); then
+    local hours=$((total / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dh %dm' "${hours}" "${minutes}"
+  else
+    local days=$((total / 86400))
+    local hours=$(((total % 86400) / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dd %dh %dm' "${days}" "${hours}" "${minutes}"
+  fi
 }
 
 prefix_lines() {
@@ -913,7 +931,7 @@ if $run_pcm_pcie; then
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_rnn_pcm_pcie.log
-  log_debug "pcm-pcie completed in ${pcm_pcie_runtime}s"
+  log_debug "pcm-pcie completed in $(secs_to_dhm "$pcm_pcie_runtime")"
 fi
 
 if $run_pcm; then
@@ -948,7 +966,7 @@ if $run_pcm; then
   pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_rnn_pcm.log
-  log_debug "pcm completed in ${pcm_runtime}s"
+  log_debug "pcm completed in $(secs_to_dhm "$pcm_runtime")"
 fi
 
 if $run_pcm_memory; then
@@ -983,7 +1001,7 @@ if $run_pcm_memory; then
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_rnn_pcm_memory.log
-  log_debug "pcm-memory completed in ${pcm_mem_runtime}s"
+  log_debug "pcm-memory completed in $(secs_to_dhm "$pcm_mem_runtime")"
 fi
 
 if $run_pcm_power; then
@@ -1907,7 +1925,7 @@ if __name__ == "__main__":
     main()
 PY
 
-  log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  log_debug "pcm-power completed in $(secs_to_dhm "$pcm_power_runtime")"
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -2059,7 +2077,7 @@ EOF
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > "$MAYA_DONE_PATH"
-  log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya completed in $(secs_to_dhm "$maya_runtime")"
 fi
 echo
 
@@ -2097,7 +2115,7 @@ if $run_toplev_basic; then
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_rnn_toplev_basic.log
-  log_debug "Toplev basic completed in ${toplev_basic_runtime}s"
+  log_debug "Toplev basic completed in $(secs_to_dhm "$toplev_basic_runtime")"
 fi
 echo
 
@@ -2132,7 +2150,7 @@ if $run_toplev_execution; then
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_rnn_toplev_execution.log
-  log_debug "Toplev execution completed in ${toplev_execution_runtime}s"
+  log_debug "Toplev execution completed in $(secs_to_dhm "$toplev_execution_runtime")"
 fi
 echo
 
@@ -2168,7 +2186,7 @@ if $run_toplev_full; then
   toplev_full_runtime=$((toplev_full_end - toplev_full_start))
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_rnn_toplev_full.log
-  log_debug "Toplev full completed in ${toplev_full_runtime}s"
+  log_debug "Toplev full completed in $(secs_to_dhm "$toplev_full_runtime")"
 fi
 echo
 

--- a/scripts/run_3.sh
+++ b/scripts/run_3.sh
@@ -583,10 +583,28 @@ pcm_power_end=0
 pcm_pcie_start=0
 pcm_pcie_end=0
 
-# Format seconds as "Xd Yh Zm"
+# Format seconds with adaptive units
 secs_to_dhm() {
-  local total=$1
-  printf '%dd %dh %dm' $((total/86400)) $(((total%86400)/3600)) $(((total%3600)/60))
+  local total=${1:-0}
+  if (( total < 0 )); then
+    total=$((-total))
+  fi
+  if (( total < 60 )); then
+    printf '%ds' "${total}"
+  elif (( total < 3600 )); then
+    local minutes=$((total / 60))
+    local seconds=$((total % 60))
+    printf '%dm %ds' "${minutes}" "${seconds}"
+  elif (( total < 86400 )); then
+    local hours=$((total / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dh %dm' "${hours}" "${minutes}"
+  else
+    local days=$((total / 86400))
+    local hours=$(((total % 86400) / 3600))
+    local minutes=$(((total % 3600) / 60))
+    printf '%dd %dh %dm' "${days}" "${hours}" "${minutes}"
+  fi
 }
 
 prefix_lines() {
@@ -906,7 +924,7 @@ if $run_pcm_pcie; then
   pcm_pcie_runtime=$((pcm_pcie_end - pcm_pcie_start))
   echo "pcm-pcie runtime: $(secs_to_dhm "$pcm_pcie_runtime")" \
     > /local/data/results/done_pcm_pcie.log
-  log_debug "pcm-pcie completed in ${pcm_pcie_runtime}s"
+  log_debug "pcm-pcie completed in $(secs_to_dhm "$pcm_pcie_runtime")"
 fi
 
 if $run_pcm; then
@@ -932,7 +950,7 @@ if $run_pcm; then
   pcm_runtime=$((pcm_end - pcm_start))
   echo "pcm runtime: $(secs_to_dhm "$pcm_runtime")" \
     > /local/data/results/done_pcm.log
-  log_debug "pcm completed in ${pcm_runtime}s"
+  log_debug "pcm completed in $(secs_to_dhm "$pcm_runtime")"
 fi
 
 if $run_pcm_memory; then
@@ -958,7 +976,7 @@ if $run_pcm_memory; then
   pcm_mem_runtime=$((pcm_mem_end - pcm_mem_start))
   echo "pcm-memory runtime: $(secs_to_dhm "$pcm_mem_runtime")" \
     > /local/data/results/done_pcm_memory.log
-  log_debug "pcm-memory completed in ${pcm_mem_runtime}s"
+  log_debug "pcm-memory completed in $(secs_to_dhm "$pcm_mem_runtime")"
 fi
 
 if $run_pcm_power; then
@@ -1873,7 +1891,7 @@ if __name__ == "__main__":
     main()
 PY
 
-  log_debug "pcm-power completed in ${pcm_power_runtime}s"
+  log_debug "pcm-power completed in $(secs_to_dhm "$pcm_power_runtime")"
 fi
 
 if $run_pcm || $run_pcm_memory || $run_pcm_power || $run_pcm_pcie; then
@@ -2018,7 +2036,7 @@ EOF
   maya_runtime=$((maya_end - maya_start))
   echo "Maya runtime:   $(secs_to_dhm "$maya_runtime")" \
     > "$MAYA_DONE_PATH"
-  log_debug "Maya completed in ${maya_runtime}s"
+  log_debug "Maya completed in $(secs_to_dhm "$maya_runtime")"
 fi
 echo
 
@@ -2050,7 +2068,7 @@ if $run_toplev_basic; then
   toplev_basic_runtime=$((toplev_basic_end - toplev_basic_start))
   echo "Toplev-basic runtime: $(secs_to_dhm "$toplev_basic_runtime")" \
     > /local/data/results/done_toplev_basic.log
-  log_debug "Toplev basic completed in ${toplev_basic_runtime}s"
+  log_debug "Toplev basic completed in $(secs_to_dhm "$toplev_basic_runtime")"
 fi
 echo
 
@@ -2080,7 +2098,7 @@ if $run_toplev_execution; then
   toplev_execution_runtime=$((toplev_execution_end - toplev_execution_start))
   echo "Toplev-execution runtime: $(secs_to_dhm "$toplev_execution_runtime")" \
     > /local/data/results/done_toplev_execution.log
-  log_debug "Toplev execution completed in ${toplev_execution_runtime}s"
+  log_debug "Toplev execution completed in $(secs_to_dhm "$toplev_execution_runtime")"
 fi
 echo
 
@@ -2111,7 +2129,7 @@ if $run_toplev_full; then
   toplev_full_runtime=$((toplev_full_end - toplev_full_start))
   echo "Toplev-full runtime: $(secs_to_dhm "$toplev_full_runtime")" \
     > /local/data/results/done_toplev_full.log
-  log_debug "Toplev full completed in ${toplev_full_runtime}s"
+  log_debug "Toplev full completed in $(secs_to_dhm "$toplev_full_runtime")"
 fi
 echo
 


### PR DESCRIPTION
## Summary
- update the secs_to_dhm helper in each run script to format durations using adaptive day/hour/minute/second units
- ensure all runtime completion log messages call the helper so run.log no longer shows long durations purely in seconds

## Testing
- for f in scripts/run_1.sh scripts/run_3.sh scripts/run_13.sh scripts/run_20_3gram_rnn.sh scripts/run_20_3gram_lm.sh scripts/run_20_3gram_llm.sh; do bash -n "$f" || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68e59bd54d64832c8a0b97d14efbfa85